### PR TITLE
0.5.8 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ env:
   - OSX_SCHEME=BezierKit_Mac
   - OSX_SDK=macosx10.14
   matrix:
-    - DESTINATION="OS=9.0,name=iPhone 5"        SCHEME="$IOS_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" POD_LINT="NO"
-    - DESTINATION="OS=11.4,name=iPhone 6"        SCHEME="$IOS_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" POD_LINT="NO"
+    - DESTINATION="OS=10.0,name=iPhone 5"        SCHEME="$IOS_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" POD_LINT="NO"
+    - DESTINATION="OS=12.0,name=iPhone 6"        SCHEME="$IOS_SCHEME"     SDK="$IOS_SDK"     RUN_TESTS="YES" POD_LINT="NO"
     - DESTINATION="arch=x86_64"                  SCHEME="$OSX_SCHEME"     SDK="$OSX_SDK"     RUN_TESTS="YES" POD_LINT="NO"
 script:
   - set -o pipefail

--- a/BezierKit.podspec
+++ b/BezierKit.podspec
@@ -5,14 +5,14 @@
 
 Pod::Spec.new do |s|
   s.name         = "BezierKit"
-  s.version      = "0.5.7"
+  s.version      = "0.5.8"
   s.summary      = "comprehensive Bezier Path library written in Swift"
   s.homepage     = "https://github.com/hfutrell/BezierKit"
   s.license      = "MIT"
   s.author       = { "Holmes Futrell" => "holmesfutrell@gmail.com" }
 
-  s.ios.deployment_target = "9.0"
-  s.osx.deployment_target = "10.10"
+  s.ios.deployment_target = "10.0"
+  s.osx.deployment_target = "10.12"
   s.ios.framework  = 'UIKit', 'CoreGraphics'
   s.osx.framework  = 'AppKit'
   #s.tvos.deployment_target = '9.0'

--- a/BezierKit/.swiftlint.yml
+++ b/BezierKit/.swiftlint.yml
@@ -1,0 +1,20 @@
+disabled_rules: # rule identifiers to exclude from running
+  - identifier_name
+  - no_fallthrough_only
+  - type_name
+# configurable rules can be customized from this configuration file
+# binary rules can set their severity level
+force_cast: warning
+type_body_length:
+  - 200  # warning
+  - 1000 # error
+line_length:
+  - 180  # warning
+  - 1000 # error
+large_tuple:
+  - 3    # warning
+  - 6    # error
+excluded:
+    BezierKitTests/
+    BezierKit_iOSTests/
+    BezierKit_MacTests/

--- a/BezierKit/BezierKit.xcodeproj/project.pbxproj
+++ b/BezierKit/BezierKit.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		FDB9D7351EB28CEB00413F0E /* BezierKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD26253B1EAC7B9A00C64652 /* BezierKit.framework */; };
 		FDB9D7421EB28D1900413F0E /* BezierKit_MacTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDB9D7411EB28D1900413F0E /* BezierKit_MacTests.swift */; };
 		FDB9D7441EB28D1900413F0E /* BezierKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FD4A0DC01EAAD01F0031A393 /* BezierKit.framework */; };
+		FDC2EB4A2298735C007768FC /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC2EB492298735C007768FC /* Lock.swift */; };
+		FDC2EB4B2298735C007768FC /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC2EB492298735C007768FC /* Lock.swift */; };
 		FDC455EE211D057E00DBF2B2 /* BoundingVolumeHierarchy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC859622119274A00AF7642 /* BoundingVolumeHierarchy.swift */; };
 		FDC7D7032111323A00A9EEF0 /* Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC7D7012111323A00A9EEF0 /* Path.swift */; };
 		FDC7D7042111323A00A9EEF0 /* Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDC7D7012111323A00A9EEF0 /* Path.swift */; };
@@ -172,6 +174,7 @@
 		FDB9D73F1EB28D1900413F0E /* BezierKit_MacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BezierKit_MacTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FDB9D7411EB28D1900413F0E /* BezierKit_MacTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BezierKit_MacTests.swift; sourceTree = "<group>"; };
 		FDB9D7431EB28D1900413F0E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FDC2EB492298735C007768FC /* Lock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		FDC7D7012111323A00A9EEF0 /* Path.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Path.swift; sourceTree = "<group>"; };
 		FDC7D705211288BD00A9EEF0 /* PathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathTests.swift; sourceTree = "<group>"; };
 		FDC859592118EC5600AF7642 /* DrawTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawTests.swift; sourceTree = "<group>"; };
@@ -318,6 +321,7 @@
 				FDB6B3FD1EAFD6DF00001C61 /* PathComponent.swift */,
 				FD149EB92135CBFF009E791D /* AugmentedGraph.swift */,
 				FDC859622119274A00AF7642 /* BoundingVolumeHierarchy.swift */,
+				FDC2EB492298735C007768FC /* Lock.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -591,6 +595,7 @@
 				FDB6B40F1EAFD6DF00001C61 /* PathComponent.swift in Sources */,
 				FDB6B4151EAFD6DF00001C61 /* Utils.swift in Sources */,
 				FDCE99A6223C404E00597989 /* Path+Data.swift in Sources */,
+				FDC2EB4B2298735C007768FC /* Lock.swift in Sources */,
 				FDB6B4071EAFD6DF00001C61 /* Draw.swift in Sources */,
 				FDB6B4131EAFD6DF00001C61 /* Types.swift in Sources */,
 				FDB6B4031EAFD6DF00001C61 /* BezierCurve.swift in Sources */,
@@ -614,6 +619,7 @@
 				FDB6B40E1EAFD6DF00001C61 /* PathComponent.swift in Sources */,
 				FDB6B4141EAFD6DF00001C61 /* Utils.swift in Sources */,
 				FDCE99A5223C404E00597989 /* Path+Data.swift in Sources */,
+				FDC2EB4A2298735C007768FC /* Lock.swift in Sources */,
 				FDB6B4061EAFD6DF00001C61 /* Draw.swift in Sources */,
 				FDB6B4121EAFD6DF00001C61 /* Types.swift in Sources */,
 				FDB6B4021EAFD6DF00001C61 /* BezierCurve.swift in Sources */,
@@ -832,6 +838,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = MacDemos/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = HolmesFutrell.BezierKitMacDemos;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -846,6 +853,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = MacDemos/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = HolmesFutrell.BezierKitMacDemos;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -865,7 +873,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = BezierKit_iOS/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.HolmesFutrell.BezierKit;
 				PRODUCT_NAME = BezierKit;
@@ -891,7 +899,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = BezierKit_iOS/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.HolmesFutrell.BezierKit;
 				PRODUCT_NAME = BezierKit;
@@ -920,7 +928,7 @@
 				INFOPLIST_FILE = BezierKit_Mac/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.HolmesFutrell.BezierKit;
 				PRODUCT_NAME = BezierKit;
 				SKIP_INSTALL = YES;
@@ -945,7 +953,7 @@
 				INFOPLIST_FILE = BezierKit_Mac/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.HolmesFutrell.BezierKit;
 				PRODUCT_NAME = BezierKit;
 				SKIP_INSTALL = YES;

--- a/BezierKit/BezierKit.xcodeproj/xcshareddata/xcschemes/BezierKit_Mac.xcscheme
+++ b/BezierKit/BezierKit.xcodeproj/xcshareddata/xcschemes/BezierKit_Mac.xcscheme
@@ -4,7 +4,7 @@
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -43,16 +43,6 @@
                   Identifier = "PathTests/testCrossingsRemovedAnotherRealWorldCase()">
                </Test>
             </SkippedTests>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FDB9D72F1EB28CEB00413F0E"
-               BuildableName = "BezierKit_iOSTests.xctest"
-               BlueprintName = "BezierKit_iOSTests"
-               ReferencedContainer = "container:BezierKit.xcodeproj">
-            </BuildableReference>
          </TestableReference>
       </Testables>
       <MacroExpansion>

--- a/BezierKit/BezierKit.xcodeproj/xcshareddata/xcschemes/BezierKit_Mac.xcscheme
+++ b/BezierKit/BezierKit.xcodeproj/xcshareddata/xcschemes/BezierKit_Mac.xcscheme
@@ -44,6 +44,16 @@
                </Test>
             </SkippedTests>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FDB9D72F1EB28CEB00413F0E"
+               BuildableName = "BezierKit_iOSTests.xctest"
+               BlueprintName = "BezierKit_iOSTests"
+               ReferencedContainer = "container:BezierKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/BezierKit/BezierKit.xcodeproj/xcshareddata/xcschemes/BezierKit_iOS.xcscheme
+++ b/BezierKit/BezierKit.xcodeproj/xcshareddata/xcschemes/BezierKit_iOS.xcscheme
@@ -40,9 +40,6 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "PathTests/testCrossingsRemovedAnotherRealWorldCase()">
-               </Test>
-               <Test
                   Identifier = "PathTests/testSubtractionPerformance()">
                </Test>
             </SkippedTests>

--- a/BezierKit/BezierKitTests/ArcApproximateableTests.swift
+++ b/BezierKit/BezierKitTests/ArcApproximateableTests.swift
@@ -10,17 +10,17 @@ import XCTest
 import BezierKit
 
 class ArcApproximateableTests: XCTestCase {
-    
+
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
+
     func isGoodApproximation(arcs: [Arc], curve: BezierCurve, accuracy: CGFloat) -> Bool {
         // we need at least one arc
         if arcs.count == 0 {
@@ -58,7 +58,7 @@ class ArcApproximateableTests: XCTestCase {
         }
         return true
     }
-    
+
     func testArc() {
         // test the constructor
         let arc = Arc(origin: CGPoint(x: 1.0, y: 1.0), radius: 1.5, startAngle: 0.0, endAngle: CGFloat.pi / 2.0)
@@ -67,12 +67,12 @@ class ArcApproximateableTests: XCTestCase {
         XCTAssertEqual(arc.startAngle, 0.0)
         XCTAssertEqual(arc.endAngle, CGFloat.pi / 2.0)
         XCTAssertEqual(arc.interval, Interval(start: 0.0, end: 1.0))
-        
+
         // test equality
         let arc2 = Arc(origin: CGPoint(x: 1.0, y: 1.0), radius: 1.5, startAngle: 0.0, endAngle: CGFloat.pi / 2.0, interval: Interval(start: 0.0, end: 1.0))
         XCTAssertEqual(arc, arc2)
         var arc3 = arc
-        arc3.origin = arc3.origin + CGPoint(x: 1.0, y: 1.0)
+        arc3.origin += CGPoint(x: 1.0, y: 1.0)
         XCTAssertNotEqual(arc, arc3)
         var arc4 = arc
         arc4.radius = 2
@@ -93,14 +93,14 @@ class ArcApproximateableTests: XCTestCase {
         XCTAssert(distance(arc.compute(0.5), CGPoint(x: 1.0, y: 1.0) + 0.75 * sqrt(2) * CGPoint(x: 1.0, y: 1.0)) < epsilon)
         XCTAssert(distance(arc.compute(1.0), CGPoint(x: 1.0, y: 2.5)) < epsilon)
     }
-    
+
     func testArcsQuadraticSingleArc() {
         let epsilon: CGFloat = 0.001
         let r: CGFloat = 100.0
         // q is close to a quarter circle centered at 0,0
         let q = QuadraticBezierCurve(start: r * CGPoint(x: 1.0, y: 0.0),
-                                     end:   r * CGPoint(x: 0.0, y: 1.0),
-                                     mid:   r * CGPoint(x: sqrt(2) / 2.0, y: sqrt(2) / 2.0),
+                                     end: r * CGPoint(x: 0.0, y: 1.0),
+                                     mid: r * CGPoint(x: sqrt(2) / 2.0, y: sqrt(2) / 2.0),
                                      t: 0.5)
         let result = q.arcs(errorThreshold: r)
         // with a big enough error threshold we should just get back one arc
@@ -119,7 +119,7 @@ class ArcApproximateableTests: XCTestCase {
         // just for good measure test that it passes the good approximation test
         XCTAssert(isGoodApproximation(arcs: result, curve: q, accuracy: r))
     }
-    
+
     func testArcsCubicMultipleArcs() {
         // c is just an arc that goes up and comes down
         let c = CubicBezierCurve(p0: CGPoint(x: 0.0, y: 0.0),
@@ -130,5 +130,5 @@ class ArcApproximateableTests: XCTestCase {
         let result = c.arcs(errorThreshold: errorThreshold)
         XCTAssert(isGoodApproximation(arcs: result, curve: c, accuracy: errorThreshold))
     }
-    
+
 }

--- a/BezierKit/BezierKitTests/AugmentedGraphTests.swift
+++ b/BezierKit/BezierKitTests/AugmentedGraphTests.swift
@@ -17,12 +17,12 @@ class AugmentedGraphTests: XCTestCase {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
+
     func intersectionsAreMutuallyLinked(_ vertex1: Vertex, _ vertex2: Vertex) -> Bool {
         if vertex1.intersectionInfo.neighbor !== vertex2 {
             return false
@@ -32,7 +32,7 @@ class AugmentedGraphTests: XCTestCase {
         }
         return true
     }
-    
+
     func crossingCountOnLinkedList(_ p: PathLinkedListRepresentation) -> Int {
         var count = 0
         p.forEachVertex {
@@ -42,7 +42,7 @@ class AugmentedGraphTests: XCTestCase {
         }
         return count
     }
-    
+
     func testMostBasic() {
         // this is the most basic test possible of the augmented graph
         // two squares that intersect at (1,0) and (0,1)
@@ -53,7 +53,7 @@ class AugmentedGraphTests: XCTestCase {
         let square2 = Path(cgPath: CGPath(rect: CGRect(origin: origin2, size: size), transform: nil))
 
         let intersections = square1.intersections(with: square2)
-        
+
         let augmentedGraph = AugmentedGraph(path1: square1, path2: square2, intersections: intersections)
 
         // check that there are two intersections
@@ -62,13 +62,13 @@ class AugmentedGraphTests: XCTestCase {
 
         let firstIntersectionLocation = CGPoint(x: 1.0, y: 0.0)
         let secondIntersectionLocation = CGPoint(x: 0.0, y: 1.0)
-        
+
         // find the first intersection on the first path
         let intersection1Path1: Vertex = augmentedGraph.list1.startingVertex(forComponentIndex: 0, elementIndex: 0).next
         XCTAssertTrue(intersection1Path1.isCrossing)
         XCTAssertEqual(intersection1Path1.location, firstIntersectionLocation)
         XCTAssertTrue(intersection1Path1.intersectionInfo.isExit)
-        
+
         // find the first intersection on the second path
         let intersection1Path2: Vertex = augmentedGraph.list2.startingVertex(forComponentIndex: 0, elementIndex: 1).next
         XCTAssertTrue(intersection1Path2.isCrossing)
@@ -76,22 +76,22 @@ class AugmentedGraphTests: XCTestCase {
         XCTAssertTrue(intersection1Path2.intersectionInfo.isEntry)
 
         XCTAssertTrue(intersectionsAreMutuallyLinked(intersection1Path1, intersection1Path2))
-        
+
         // find the second intersection on the first path
         let intersection2Path1: Vertex = augmentedGraph.list1.startingVertex(forComponentIndex: 0, elementIndex: 3).next
         XCTAssertTrue(intersection2Path1.isCrossing)
         XCTAssertEqual(intersection2Path1.location, secondIntersectionLocation)
         XCTAssertTrue(intersection2Path1.intersectionInfo.isEntry)
-        
+
         // find the second intersection on the second path
         let intersection2Path2: Vertex = augmentedGraph.list2.startingVertex(forComponentIndex: 0, elementIndex: 2).next
         XCTAssertTrue(intersection2Path2.isCrossing)
         XCTAssertEqual(intersection2Path2.location, secondIntersectionLocation)
         XCTAssertTrue(intersection2Path2.intersectionInfo.isExit)
-        
+
         XCTAssertTrue(intersectionsAreMutuallyLinked(intersection1Path1, intersection1Path2))
     }
-    
+
     func testCornersIntersect() {
         // this tests two squares that intersect at two of their corners
         // the first square has the origin 0,0 and a width and height of 2
@@ -105,63 +105,62 @@ class AugmentedGraphTests: XCTestCase {
         square2CGPath.addLine(to: CGPoint(x: 2.0, y: 0.0))
         square2CGPath.addLine(to: CGPoint(x: 1.0, y: 1.0))
         square2CGPath.closeSubpath()
-        
+
         let square2 = Path(cgPath: square2CGPath)
 
         let intersections = square1.intersections(with: square2)
         let augmentedGraph = AugmentedGraph(path1: square1, path2: square2, intersections: intersections)
-        
+
         // check that there are two intersections
         XCTAssertEqual(crossingCountOnLinkedList(augmentedGraph.list1), 2)
         XCTAssertEqual(crossingCountOnLinkedList(augmentedGraph.list2), 2)
 
         let firstIntersectionLocation = CGPoint(x: 0.0, y: 0.0)
         let secondIntersectionLocation = CGPoint(x: 2.0, y: 0.0)
-        
+
         // find the first intersection on the first path
         let intersection1Path1: Vertex = augmentedGraph.list1.startingVertex(forComponentIndex: 0, elementIndex: 0)
         XCTAssertTrue(intersection1Path1.isCrossing)
         XCTAssertEqual(intersection1Path1.location, firstIntersectionLocation)
         XCTAssertTrue(intersection1Path1.intersectionInfo.isEntry)
-        
+
         // find the first intersection on the second path
         let intersection1Path2: Vertex = augmentedGraph.list2.startingVertex(forComponentIndex: 0, elementIndex: 0)
         XCTAssertTrue(intersection1Path2.isCrossing)
         XCTAssertEqual(intersection1Path2.location, firstIntersectionLocation)
         XCTAssertTrue(intersection1Path2.intersectionInfo.isExit)
-        
+
         XCTAssertTrue(intersectionsAreMutuallyLinked(intersection1Path1, intersection1Path2))
-        
+
         // find the second intersection on the first path
         let intersection2Path1: Vertex = augmentedGraph.list1.startingVertex(forComponentIndex: 0, elementIndex: 1)
         XCTAssertTrue(intersection2Path1.isCrossing)
         XCTAssertEqual(intersection2Path1.location, secondIntersectionLocation)
         XCTAssertTrue(intersection2Path1.intersectionInfo.isExit)
-        
+
         // find the second intersection on the second path
         let intersection2Path2: Vertex = augmentedGraph.list2.startingVertex(forComponentIndex: 0, elementIndex: 2)
         XCTAssertTrue(intersection2Path2.isCrossing)
         XCTAssertEqual(intersection2Path2.location, secondIntersectionLocation)
         XCTAssertTrue(intersection2Path2.intersectionInfo.isEntry)
-        
+
         XCTAssertTrue(intersectionsAreMutuallyLinked(intersection1Path1, intersection1Path2))
     }
-    
+
     func testBetween() {
         let v1 = CGPoint(x: 2, y: -1)
         let v2 = CGPoint(x: 1, y: 3)
-        
+
         XCTAssertTrue( between(CGPoint(x: 3, y: -1), v1, v2)    )
         XCTAssertTrue( between(CGPoint(x: 1, y: 2), v1, v2)    )
         XCTAssertTrue( between(CGPoint(x: 3, y: -1), v1, v2)    )
-       
+
         XCTAssertFalse( between(CGPoint(x: -1, y: 1), v1, v2)    )
         XCTAssertFalse( between(CGPoint(x: 1, y: 5), v1, v2)    )
         XCTAssertFalse( between(CGPoint(x: 1, y: -1), v1, v2)    )
 
-        
     }
-    
+
     func testWindingDirection() {
         // if this test fails it's likely that the increment / decrement of the winding direction in the augmented graph is flipped from what it should be
         // the first square begins its path *inside* the second square so only if the winding count is properly decremented (to zero) at the first crossing
@@ -173,7 +172,7 @@ class AugmentedGraphTests: XCTestCase {
 
         let square1 = Path(cgPath: CGPath(rect: CGRect(origin: origin1, size: size1), transform: nil))
         let square2 = Path(cgPath: CGPath(rect: CGRect(origin: origin2, size: size2), transform: nil))
-        
+
         let intersections = square1.intersections(with: square2)
         let augmentedGraph = AugmentedGraph(path1: square1, path2: square2, intersections: intersections)
 
@@ -183,9 +182,9 @@ class AugmentedGraphTests: XCTestCase {
         let intersection2Path1: Vertex = augmentedGraph.list1.startingVertex(forComponentIndex: 0, elementIndex: 2).next
         XCTAssertTrue(intersection2Path1.intersectionInfo.isEntry)
     }
-    
+
 //    func testMultipleIntersectionsSameElement() {
 //
 //    }
-    
+
 }

--- a/BezierKit/BezierKitTests/BezierCurveTests.swift
+++ b/BezierKit/BezierKitTests/BezierCurveTests.swift
@@ -10,23 +10,23 @@ import XCTest
 @testable import BezierKit
 
 class BezierCurveTests: XCTestCase {
-    
+
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
+
     func testEquality() {
         // two lines that are equal
         let l1: BezierCurve = LineSegment(p0: CGPoint(x: 0, y: 1), p1: CGPoint(x: 2, y: 1))
         let l2: BezierCurve = LineSegment(p0: CGPoint(x: 0, y: 1), p1: CGPoint(x: 2, y: 1))
         XCTAssert(l1 == l2)
-        
+
         // a line that isn't equal
         let l3: BezierCurve = LineSegment(p0: CGPoint(x: 0, y: 1), p1: CGPoint(x: 2, y: 2))
         XCTAssertFalse(l1 == l3)
@@ -35,7 +35,7 @@ class BezierCurveTests: XCTestCase {
         let q1: BezierCurve = QuadraticBezierCurve(lineSegment: l1 as! LineSegment)
         XCTAssertFalse(l1 == q1)
     }
-    
+
     func testScaleDistance() {
         // line segment
         let epsilon: CGFloat = 1.0e-5
@@ -81,10 +81,10 @@ class BezierCurveTests: XCTestCase {
         let offset = CGPoint(x: 0, y: 1)
         let aOffset = a + offset
         let bOffset = b + offset
-        let expectedResult = CubicBezierCurve(p0: aOffset , p1: aOffset, p2: bOffset, p3: bOffset)
+        let expectedResult = CubicBezierCurve(p0: aOffset, p1: aOffset, p2: bOffset, p3: bOffset)
         XCTAssertEqual(result, expectedResult)
     }
-    
+
     func testOffsetDistance() {
         // line segments (or isLinear) have a separate codepath, so be sure to test those
         let epsilon: CGFloat = 1.0e-6
@@ -102,8 +102,7 @@ class BezierCurveTests: XCTestCase {
             if i == 0 {
                 // segment starts where un-reduced segment started (after ofsetting)
                 XCTAssert(distance(c.startingPoint, CGPoint(x: 0.0, y: 2.0)) < epsilon)
-            }
-            else {
+            } else {
                 // segment starts where last ended
                 XCTAssertEqual(c.startingPoint, c2Offset[i-1].endingPoint)
             }
@@ -113,7 +112,7 @@ class BezierCurveTests: XCTestCase {
             }
         }
     }
-    
+
     func testOffsetTimeDistance() {
         let epsilon: CGFloat = 1.0e-6
         let q = QuadraticBezierCurve(p0: CGPoint(x: 1.0, y: 1.0),
@@ -126,7 +125,7 @@ class BezierCurveTests: XCTestCase {
         XCTAssert(distance(p1, CGPoint(x: 2.0, y: 3.0)) < epsilon)
         XCTAssert(distance(p2, CGPoint(x: 4.0, y: 2.0)) < epsilon)
     }
-    
+
     func testProject() {
         // line segments override the project implementation, so test them specifically
         let epsilon: CGFloat = 2.0e-4
@@ -159,7 +158,7 @@ class BezierCurveTests: XCTestCase {
         XCTAssert(distance(p7.point, expectedAnswer) < epsilon)
         XCTAssert(abs(p7.t - t) < epsilon)
     }
-    
+
     static let lineSegmentForOutlining = LineSegment(p0: CGPoint(x: -10, y: -5), p1: CGPoint(x: 20, y: 10))
 
     private func lineOffsets(_ lineSegment: LineSegment, _ d1: CGFloat, _ d2: CGFloat, _ d3: CGFloat, _ d4: CGFloat) -> (CGPoint, CGPoint, CGPoint, CGPoint) {
@@ -169,15 +168,15 @@ class BezierCurveTests: XCTestCase {
         let o3 = lineSegment.startingPoint - d2 * lineSegment.normal(0)
         return (o0, o1, o2, o3)
     }
-    
+
     func testOutlineDistance() {
         // When only one distance value is given, the outline is generated at distance d on both the normal and anti-normal
         let lineSegment = BezierCurveTests.lineSegmentForOutlining
         let outline: PathComponent = lineSegment.outline(distance: 1)
         XCTAssertEqual(outline.elementCount, 4)
-        
+
         let (o0, o1, o2, o3) = lineOffsets(lineSegment, 1, 1, 1, 1)
-        
+
         XCTAssert( BezierKitTestHelpers.curve(outline.element(at: 0), matchesCurve: LineSegment(p0: o3, p1: o0)))
         XCTAssert( BezierKitTestHelpers.curve(outline.element(at: 1), matchesCurve: LineSegment(p0: o0, p1: o1)))
         XCTAssert( BezierKitTestHelpers.curve(outline.element(at: 2), matchesCurve: LineSegment(p0: o1, p1: o2)))
@@ -191,18 +190,18 @@ class BezierCurveTests: XCTestCase {
         let distanceOppositeNormal: CGFloat = 2
         let outline: PathComponent = lineSegment.outline(distanceAlongNormal: distanceAlongNormal, distanceOppositeNormal: distanceOppositeNormal)
         XCTAssertEqual(outline.elementCount, 4)
-        
+
         let o0 = lineSegment.startingPoint + distanceAlongNormal * lineSegment.normal(0)
         let o1 = lineSegment.endingPoint + distanceAlongNormal * lineSegment.normal(1)
         let o2 = lineSegment.endingPoint - distanceOppositeNormal * lineSegment.normal(1)
         let o3 = lineSegment.startingPoint - distanceOppositeNormal * lineSegment.normal(0)
-        
+
         XCTAssert( BezierKitTestHelpers.curve(outline.element(at: 0), matchesCurve: LineSegment(p0: o3, p1: o0)))
         XCTAssert( BezierKitTestHelpers.curve(outline.element(at: 1), matchesCurve: LineSegment(p0: o0, p1: o1)))
         XCTAssert( BezierKitTestHelpers.curve(outline.element(at: 2), matchesCurve: LineSegment(p0: o1, p1: o2)))
         XCTAssert( BezierKitTestHelpers.curve(outline.element(at: 3), matchesCurve: LineSegment(p0: o2, p1: o3)))
     }
-    
+
     func testOutlineFourArguments() {
         // Graduated offsetting is achieved by using four distances measures, where d1 is the initial offset along the normal, d2 the initial distance along the anti-normal, d3 the final offset along the normal, and d4 the final offset along the anti-normal.
         let lineSegment = BezierCurveTests.lineSegmentForOutlining
@@ -215,9 +214,9 @@ class BezierCurveTests: XCTestCase {
                                                       distanceOppositeNormalStart: distanceOppositeNormal1,
                                                       distanceAlongNormalEnd: distanceAlongNormal2,
                                                       distanceOppositeNormalEnd: distanceOppositeNormal2)
-        
+
         XCTAssertEqual(outline.elementCount, 4)
-        
+
         let (o0, o1, o2, o3) = lineOffsets(lineSegment, distanceAlongNormal1, distanceOppositeNormal1, distanceAlongNormal2, distanceOppositeNormal2)
 
         XCTAssert( BezierKitTestHelpers.curve(outline.element(at: 0), matchesCurve: LineSegment(p0: o3, p1: o0)))
@@ -230,15 +229,15 @@ class BezierCurveTests: XCTestCase {
         // we need this special test for quadratics for two reasons:
         // 1. scale has a special case for linear
         // 2. quadratics are upgrade in the outline function (why?)
-        
+
         let q = QuadraticBezierCurve(p0: CGPoint(x: 0.0, y: 0.0), p1: CGPoint(x: 9.0, y: 11.0), p2: CGPoint(x: 20.0, y: 20.0))
         let outline: PathComponent = q.outline(distanceAlongNormalStart: sqrt(2), distanceOppositeNormalStart: sqrt(2), distanceAlongNormalEnd: 2 * sqrt(2), distanceOppositeNormalEnd: 2 * sqrt(2))
-        
+
         let expectedSegment1 = LineSegment(p0: CGPoint(x: 1, y: -1), p1: CGPoint(x: -1, y: 1))
         let expectedSegment2 = QuadraticBezierCurve(p0: CGPoint(x: -1, y: 1), p1: CGPoint(x: 7.5, y: 12.5), p2: CGPoint(x: 18, y: 22))
         let expectedSegment3 = LineSegment(p0: CGPoint(x: 18, y: 22), p1: CGPoint(x: 22, y: 18))
         let expectedSegment4 = QuadraticBezierCurve(p0: CGPoint(x: 22, y: 18), p1: CGPoint(x: 10.5, y: 9.5), p2: CGPoint(x: 1, y: -1))
-        
+
         XCTAssertEqual(outline.elementCount, 4)
         // hard to compute this outline exactly, so just check the computed value roughly equals our estimate of what it should be
         XCTAssert( BezierKitTestHelpers.curve(outline.element(at: 0), matchesCurve: expectedSegment1, tolerance: 0.33 ))
@@ -246,31 +245,31 @@ class BezierCurveTests: XCTestCase {
         XCTAssert( BezierKitTestHelpers.curve(outline.element(at: 2), matchesCurve: expectedSegment3, tolerance: 0.33 ))
         XCTAssert( BezierKitTestHelpers.curve(outline.element(at: 3), matchesCurve: expectedSegment4, tolerance: 0.33 ))
     }
-    
+
     func testOutlineQuadraticNormalsParallel() {
         // this tests a special corner case of outlines where endpoint normals are parallel
-    
+
         let q = QuadraticBezierCurve(p0: CGPoint(x: 0.0, y: 0.0), p1: CGPoint(x: 5.0, y: 0.0), p2: CGPoint(x: 10.0, y: 0.0))
         let outline: PathComponent = q.outline(distance: 1)
-        
+
         let expectedSegment1 = LineSegment(p0: CGPoint(x: 0, y: -1), p1: CGPoint(x: 0, y: 1))
         let expectedSegment2 = LineSegment(p0: CGPoint(x: 0, y: 1), p1: CGPoint(x: 10, y: 1))
         let expectedSegment3 = LineSegment(p0: CGPoint(x: 10, y: 1), p1: CGPoint(x: 10, y: -1))
         let expectedSegment4 = LineSegment(p0: CGPoint(x: 10, y: -1), p1: CGPoint(x: 0, y: -1))
-        
+
         XCTAssertEqual(outline.elementCount, 4)
         XCTAssert( BezierKitTestHelpers.curve(outline.element(at: 0), matchesCurve: expectedSegment1 ))
         XCTAssert( BezierKitTestHelpers.curve(outline.element(at: 1), matchesCurve: expectedSegment2 ))
         XCTAssert( BezierKitTestHelpers.curve(outline.element(at: 2), matchesCurve: expectedSegment3 ))
         XCTAssert( BezierKitTestHelpers.curve(outline.element(at: 3), matchesCurve: expectedSegment4 ))
     }
-    
+
     func testOutlineFourArgumentsQuadraticNormalsParallel() {
         // this tests a special corner case of tapered outlines where endpoint normals are parallel
-     
+
         let q = QuadraticBezierCurve(p0: CGPoint(x: 0.0, y: 0.0), p1: CGPoint(x: 10.0, y: 0.0), p2: CGPoint(x: 20.0, y: 0.0))
         let outline: PathComponent = q.outline(distanceAlongNormalStart: 2, distanceOppositeNormalStart: 2, distanceAlongNormalEnd: 1, distanceOppositeNormalEnd: 1)
-        
+
         let expectedSegment1 = LineSegment(p0: CGPoint(x: 0.0, y: -2.0), p1: CGPoint(x: 0.0, y: 2.0))
         let expectedSegment2 = LineSegment(p0: CGPoint(x: 0.0, y: 2.0), p1: CGPoint(x: 20.0, y: 1.0))
         let expectedSegment3 = LineSegment(p0: CGPoint(x: 20.0, y: 1.0), p1: CGPoint(x: 20.0, y: -1.0))
@@ -282,7 +281,7 @@ class BezierCurveTests: XCTestCase {
         XCTAssert( BezierKitTestHelpers.curve(outline.element(at: 2), matchesCurve: expectedSegment3 ))
         XCTAssert( BezierKitTestHelpers.curve(outline.element(at: 3), matchesCurve: expectedSegment4 ))
     }
-    
+
     func testOutlineShapesDistance() {
         let lineSegment = BezierCurveTests.lineSegmentForOutlining
         let distanceAlongNormal: CGFloat = 1
@@ -292,7 +291,7 @@ class BezierCurveTests: XCTestCase {
         let expectedShape = Shape(LineSegment(p0: o0, p1: o1), LineSegment(p0: o2, p1: o3), false, false) // shape made from lines with real (non-virtual) caps
         XCTAssertTrue( BezierKitTestHelpers.shape(shapes[0], matchesShape: expectedShape) )
     }
-    
+
     func testOutlineShapesDistanceAlongNormalDistanceOppositeNormal() {
         let lineSegment = BezierCurveTests.lineSegmentForOutlining
         let distanceAlongNormal: CGFloat = 1
@@ -303,7 +302,7 @@ class BezierCurveTests: XCTestCase {
         let expectedShape = Shape(LineSegment(p0: o0, p1: o1), LineSegment(p0: o2, p1: o3), false, false) // shape made from lines with real (non-virtual) caps
         XCTAssertTrue( BezierKitTestHelpers.shape(shapes[0], matchesShape: expectedShape) )
     }
-    
+
     func testCubicCubicIntersectionEndpoints() {
         // these two cubics intersect only at the endpoints
         let epsilon: CGFloat = 1.0e-3
@@ -322,7 +321,7 @@ class BezierCurveTests: XCTestCase {
         XCTAssertEqual(i[1].t1, 1.0)
         XCTAssertEqual(i[1].t2, 0.0)
     }
-    
+
     func testCubicSelfIntersection() {
         let epsilon: CGFloat = 1.0e-3
         let curve = CubicBezierCurve(p0: CGPoint(x: 0.0, y: 0.0),

--- a/BezierKit/BezierKitTests/BezierKitTestHelpers.swift
+++ b/BezierKit/BezierKitTests/BezierKitTestHelpers.swift
@@ -26,7 +26,7 @@ class BezierKitTestHelpers {
         if c1.order != c2.order {
             return false
         }
-        guard zip(c1.points, c2.points).contains(where: { distance($0, $1) > epsilon }) == false else {
+        guard zip(c1.points, c2.points).allSatisfy({ distance($0, $1) <= epsilon }) else {
             return false
         }
         return true

--- a/BezierKit/BezierKitTests/BezierKitTestHelpers.swift
+++ b/BezierKit/BezierKitTests/BezierKitTestHelpers.swift
@@ -21,20 +21,18 @@ class BezierKitTestHelpers {
         }
         return true
     }
-    
+
     static internal func curveControlPointsEqual(curve1 c1: BezierCurve, curve2 c2: BezierCurve, tolerance epsilon: CGFloat) -> Bool {
         if c1.order != c2.order {
             return false
         }
-        for i in 0...c1.order {
-            if (c1.points[i] - c2.points[i]).length > epsilon {
-                return false
-            }
+        guard zip(c1.points, c2.points).contains(where: { distance($0, $1) > epsilon }) == false else {
+            return false
         }
         return true
     }
-    
-    static internal func shape(_ s: Shape,  matchesShape other: Shape, tolerance: CGFloat = 1.0e-6) -> Bool {
+
+    static internal func shape(_ s: Shape, matchesShape other: Shape, tolerance: CGFloat = 1.0e-6) -> Bool {
         guard BezierKitTestHelpers.curve(s.forward, matchesCurve: other.forward, tolerance: tolerance) else {
             return false
         }
@@ -55,7 +53,7 @@ class BezierKitTestHelpers {
         }
         return true
     }
-    
+
     static internal func curve(_ c1: BezierCurve, matchesCurve c2: BezierCurve, overInterval interval: Interval = Interval(start: 0.0, end: 1.0), tolerance: CGFloat = 1.0e-5) -> Bool {
         // checks if c1 over [0, 1] matches c2 over [interval.start, interval.end]
         // useful for checking if splitting a curve over a given interval worked correctly
@@ -69,7 +67,7 @@ class BezierKitTestHelpers {
         }
         return true
     }
-    
+
     private static func evaluatePolynomial(_ p: [CGFloat], at t: CGFloat) -> CGFloat {
         var sum: CGFloat = 0.0
         for n in 0..<p.count {
@@ -149,5 +147,5 @@ class BezierKitTestHelpers {
 //        }
 //        return curve
 //    }
-            
+
 }

--- a/BezierKit/BezierKitTests/BoundingBoxTests.swift
+++ b/BezierKit/BezierKitTests/BoundingBoxTests.swift
@@ -10,28 +10,28 @@ import XCTest
 @testable import BezierKit
 
 class BoundingBoxTests: XCTestCase {
-    
+
     let pointNan        = CGPoint(x: CGFloat.nan, y: CGFloat.nan)
     let zeroBox         = BoundingBox(p1: .zero, p2: .zero)
     let infiniteBox     = BoundingBox(p1: -.infinity, p2: .infinity)
     let sampleBox       = BoundingBox(p1: CGPoint(x: -1.0, y: -2.0), p2: CGPoint(x: 3.0, y: -1.0))
-    
+
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
+
     func testEmpty() {
         let nanBox = BoundingBox(p1: pointNan, p2: pointNan)
         let e = BoundingBox.empty
         XCTAssert(e.size == .zero)
         XCTAssertTrue(e == BoundingBox.empty)
-        
+
         XCTAssertFalse(e.overlaps(e))
         XCTAssertFalse(e.overlaps(zeroBox))
         XCTAssertFalse(e.overlaps(sampleBox))
@@ -39,36 +39,36 @@ class BoundingBoxTests: XCTestCase {
         XCTAssertFalse(e.overlaps(nanBox))
 
     }
-    
+
     func testLowerAndUpperBounds() {
         let box = BoundingBox(p1: CGPoint(x: 2.0, y: 3.0), p2: CGPoint(x: 3.0, y: 5.0))
-        
+
         let p1 = CGPoint(x: 2.0, y: 4.0)
         let p2 = CGPoint(x: 2.5, y: 3.5)
         let p3 = CGPoint(x: 1.0, y: 4.0)
         let p4 = CGPoint(x: 3.0, y: 7.0)
         let p5 = CGPoint(x: -1.0, y: -1.0)
-        
+
         XCTAssertEqual(box.lowerBoundOfDistance(to: p1), 0.0)    // on the boundary
         XCTAssertEqual(box.lowerBoundOfDistance(to: p2), 0.0)    // fully inside
         XCTAssertEqual(box.lowerBoundOfDistance(to: p3), 1.0)    // outside (straight horizontally)
         XCTAssertEqual(box.lowerBoundOfDistance(to: p4), 2.0)    // outside (straight vertically)
         XCTAssertEqual(box.lowerBoundOfDistance(to: p5), 5.0)  // outside (nearest bottom left corner)
-        
+
         XCTAssertEqual(box.upperBoundOfDistance(to: p1), sqrt(2.0))
         XCTAssertEqual(box.upperBoundOfDistance(to: p2), sqrt(2.5))
         XCTAssertEqual(box.upperBoundOfDistance(to: p3), sqrt(5))
         XCTAssertEqual(box.upperBoundOfDistance(to: p4), sqrt(17.0))
         XCTAssertEqual(box.upperBoundOfDistance(to: p5), sqrt(52.0))
     }
-    
+
     func testArea() {
         let box = BoundingBox(p1: CGPoint(x: 2.0, y: 3.0), p2: CGPoint(x: 3.0, y: 5.0))
         XCTAssertEqual(box.area, 2.0)
         let emptyBox = BoundingBox.empty
         XCTAssertEqual(emptyBox.area, 0.0)
     }
-    
+
     func testOverlaps() {
         let box1 = BoundingBox(p1: CGPoint(x: 2.0, y: 3.0), p2: CGPoint(x: 3.0, y: 5.0))
         let box2 = BoundingBox(p1: CGPoint(x: 2.5, y: 6.0), p2: CGPoint(x: 3.0, y: 8.0))
@@ -77,25 +77,25 @@ class BoundingBoxTests: XCTestCase {
         XCTAssertTrue(box1.overlaps(box3))
         XCTAssertFalse(box1.overlaps(BoundingBox.empty))
     }
-    
+
     func testUnionEmpty1() {
         var empty1 = BoundingBox.empty
         let empty2 = BoundingBox.empty
         XCTAssertEqual(empty1.union(empty2), BoundingBox.empty)
     }
-    
+
     func testUnionEmpty2() {
         var empty = BoundingBox.empty
         let box = BoundingBox(p1: CGPoint(x: 2.0, y: 3.0), p2: CGPoint(x: 3.0, y: 5.0))
         XCTAssertEqual(empty.union(box), box)
     }
-    
+
     func testUnion() {
         var box1 = BoundingBox(p1: CGPoint(x: 2.0, y: 3.0), p2: CGPoint(x: 3.0, y: 5.0))
         let box2 = BoundingBox(p1: CGPoint(x: 2.5, y: 6.0), p2: CGPoint(x: 3.0, y: 8.0))
         XCTAssertEqual(box1.union(box2), BoundingBox(p1: CGPoint(x: 2.0, y: 3.0), p2: CGPoint(x: 3.0, y: 8.0)))
     }
-    
+
     func testCGRect() {
         // test a standard box
         let box1 = BoundingBox(p1: CGPoint(x: 2.0, y: 3.0), p2: CGPoint(x: 3.0, y: 5.0))
@@ -110,23 +110,23 @@ class BoundingBoxTests: XCTestCase {
         let result = BoundingBox(first: box1, second: box2)
         XCTAssertEqual(result, BoundingBox(p1: CGPoint(x: 1.0, y: 1.0), p2: CGPoint(x: 3.0, y: 5.0)))
     }
-    
+
     func testIntersection() {
-        let box1 = BoundingBox(p1: CGPoint(x:0,y:0), p2: CGPoint(x:3,y:2))
-        let box2 = BoundingBox(p1: CGPoint(x:2,y:1), p2: CGPoint(x:4,y:5))      // overlaps box1
-        let box3 = BoundingBox(p1: CGPoint(x:2,y:4), p2: CGPoint(x:4,y:5))      // does not overlap box1
-        let box4 = BoundingBox(p1: CGPoint(x:3,y:0), p2: CGPoint(x:5,y:2))      // overlaps box1 exactly on x edge
-        let box5 = BoundingBox(p1: CGPoint(x:0,y:2), p2: CGPoint(x:3,y:4))      // overlaps box1 exactly on y edge
-        let box6 = BoundingBox(p1: CGPoint(x:0,y:0), p2: CGPoint(x:-5,y:-5))    // overlaps box1 only at (0,0)
-        let expectedBox = BoundingBox(p1: CGPoint(x:2,y:1), p2: CGPoint(x:3,y:2))
+        let box1 = BoundingBox(p1: CGPoint(x: 0, y: 0), p2: CGPoint(x: 3, y: 2))
+        let box2 = BoundingBox(p1: CGPoint(x: 2, y: 1), p2: CGPoint(x: 4, y: 5))      // overlaps box1
+        let box3 = BoundingBox(p1: CGPoint(x: 2, y: 4), p2: CGPoint(x: 4, y: 5))      // does not overlap box1
+        let box4 = BoundingBox(p1: CGPoint(x: 3, y: 0), p2: CGPoint(x: 5, y: 2))      // overlaps box1 exactly on x edge
+        let box5 = BoundingBox(p1: CGPoint(x: 0, y: 2), p2: CGPoint(x: 3, y: 4))      // overlaps box1 exactly on y edge
+        let box6 = BoundingBox(p1: CGPoint(x: 0, y: 0), p2: CGPoint(x: -5, y: -5))    // overlaps box1 only at (0,0)
+        let expectedBox = BoundingBox(p1: CGPoint(x: 2, y: 1), p2: CGPoint(x: 3, y: 2))
         XCTAssertEqual(box1.intersection(box2), expectedBox)
         XCTAssertEqual(box2.intersection(box1), expectedBox)
         XCTAssertEqual(box1.intersection(box3), BoundingBox.empty)
         XCTAssertEqual(box1.intersection(BoundingBox.empty), BoundingBox.empty)
         XCTAssertEqual(BoundingBox.empty.intersection(box1), BoundingBox.empty)
         XCTAssertEqual(BoundingBox.empty.intersection(BoundingBox.empty), BoundingBox.empty)
-        XCTAssertEqual(box1.intersection(box4), BoundingBox(p1: CGPoint(x:3,y:0), p2: CGPoint(x:3,y:2)))
-        XCTAssertEqual(box1.intersection(box5), BoundingBox(p1: CGPoint(x:0,y:2), p2: CGPoint(x:3,y:2)))
+        XCTAssertEqual(box1.intersection(box4), BoundingBox(p1: CGPoint(x: 3, y: 0), p2: CGPoint(x: 3, y: 2)))
+        XCTAssertEqual(box1.intersection(box5), BoundingBox(p1: CGPoint(x: 0, y: 2), p2: CGPoint(x: 3, y: 2)))
         XCTAssertEqual(box1.intersection(box6), BoundingBox(p1: CGPoint.zero, p2: CGPoint.zero))
     }
 }

--- a/BezierKit/BezierKitTests/BoundingBoxTests.swift
+++ b/BezierKit/BezierKitTests/BoundingBoxTests.swift
@@ -38,6 +38,11 @@ class BoundingBoxTests: XCTestCase {
         XCTAssertFalse(e.overlaps(infiniteBox))
         XCTAssertFalse(e.overlaps(nanBox))
 
+        XCTAssertFalse(infiniteBox.isEmpty)
+        XCTAssertFalse(zeroBox.isEmpty)
+        XCTAssertFalse(sampleBox.isEmpty)
+        XCTAssertTrue(BoundingBox.empty.isEmpty)
+        XCTAssertTrue(BoundingBox(min: CGPoint(x: 5, y: 3), max: CGPoint(x: 4, y: 4)).isEmpty)
     }
 
     func testLowerAndUpperBounds() {
@@ -53,7 +58,7 @@ class BoundingBoxTests: XCTestCase {
         XCTAssertEqual(box.lowerBoundOfDistance(to: p2), 0.0)    // fully inside
         XCTAssertEqual(box.lowerBoundOfDistance(to: p3), 1.0)    // outside (straight horizontally)
         XCTAssertEqual(box.lowerBoundOfDistance(to: p4), 2.0)    // outside (straight vertically)
-        XCTAssertEqual(box.lowerBoundOfDistance(to: p5), 5.0)  // outside (nearest bottom left corner)
+        XCTAssertEqual(box.lowerBoundOfDistance(to: p5), 5.0)    // outside (nearest bottom left corner)
 
         XCTAssertEqual(box.upperBoundOfDistance(to: p1), sqrt(2.0))
         XCTAssertEqual(box.upperBoundOfDistance(to: p2), sqrt(2.5))

--- a/BezierKit/BezierKitTests/BoundingVolumeHierarchyTests.swift
+++ b/BezierKit/BezierKitTests/BoundingVolumeHierarchyTests.swift
@@ -16,11 +16,11 @@ private struct Tuple: Equatable, Hashable {
 }
 
 class BoundingVolumeHierarchyTests: XCTestCase {
-    
+
     // initializer
     // intersects()
     // intersects(node:)
-    
+
     func testIntersectsVisitsEachOnce() {
         // in this test each bounding box is identical and therefore
         // each bounding box overlaps. What we are testing here is that

--- a/BezierKit/BezierKitTests/CGPointTests.swift
+++ b/BezierKit/BezierKitTests/CGPointTests.swift
@@ -25,7 +25,7 @@ class CGPointTests: XCTestCase {
         var p3 = CGPoint(x: 5.0, y: 3.0)
         p3 += CGPoint(x: 1.0, y: -2.0)
         XCTAssertEqual(p3, CGPoint(x: 6.0, y: 1.0))
-        
+
         var p4 = CGPoint(x: 2.0, y: 9.0)
         p4 -= CGPoint(x: 2.0, y: 8.0)
         XCTAssertEqual(p4, CGPoint(x: 0.0, y: 1.0))
@@ -36,7 +36,7 @@ class CGPointTests: XCTestCase {
         XCTAssertEqual(p5[0], 1.25)
         XCTAssertEqual(p5[1], 6.25)
     }
-    
+
     func testFunctions() {
         let a = CGPoint(x: 3, y: 4)
         let b = CGPoint(x: -1, y: 5)

--- a/BezierKit/BezierKitTests/CubicBezierCurveTests.swift
+++ b/BezierKit/BezierKitTests/CubicBezierCurveTests.swift
@@ -319,6 +319,16 @@ class CubicBezierCurveTests: XCTestCase {
         let result3 = c3.reduce()
         XCTAssertTrue(BezierKitTestHelpers.isSatisfactoryReduceResult(result3, for: c3))
     }
+
+    func testReduceExtremaCloseby() {
+        // the x coordinates are f(t) = (t-0.5)^2 = t^2 - t + 0.25, which has a minima at t=0.5
+        // the y coordinates are f(t) = 1/3t^3 - 1/2t^2 + 3/16t, which has an inflection at t=0.5
+        // adding `smallValue` to one of the y coordinates gives us two extrema very close to t=0.5
+        let smallValue: CGFloat = 1.0e-3
+        let c = BezierKitTestHelpers.cubicBezierCurveFromPolynomials([0,1,-1,0.25], [CGFloat(1.0 / 3.0), CGFloat(-1.0 / 2.0) + smallValue, CGFloat(3.0 / 16.0),0])
+        let result1 = c.reduce()
+        XCTAssertTrue(BezierKitTestHelpers.isSatisfactoryReduceResult(result1, for: c))
+    }
 //
 //    //    func testScaleDistanceFunc {
 //    //

--- a/BezierKit/BezierKitTests/CubicBezierCurveTests.swift
+++ b/BezierKit/BezierKitTests/CubicBezierCurveTests.swift
@@ -15,12 +15,12 @@ class CubicBezierCurveTests: XCTestCase {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
+
     func testInitializerArray() {
         let c = CubicBezierCurve(points: [CGPoint(x: 1.0, y: 1.0), CGPoint(x: 3.0, y: 2.0), CGPoint(x: 5.0, y: 3.0), CGPoint(x: 7.0, y: 4.0)])
         XCTAssertEqual(c.p0, CGPoint(x: 1.0, y: 1.0))
@@ -30,7 +30,7 @@ class CubicBezierCurveTests: XCTestCase {
         XCTAssertEqual(c.startingPoint, CGPoint(x: 1.0, y: 1.0))
         XCTAssertEqual(c.endingPoint, CGPoint(x: 7.0, y: 4.0))
     }
-    
+
     func testInitializerIndividualPoints() {
         let c = CubicBezierCurve(p0: CGPoint(x: 1.0, y: 1.0), p1: CGPoint(x: 3.0, y: 2.0), p2: CGPoint(x: 5.0, y: 3.0), p3: CGPoint(x: 7.0, y: 4.0))
         XCTAssertEqual(c.p0, CGPoint(x: 1.0, y: 1.0))
@@ -40,7 +40,7 @@ class CubicBezierCurveTests: XCTestCase {
         XCTAssertEqual(c.startingPoint, CGPoint(x: 1.0, y: 1.0))
         XCTAssertEqual(c.endingPoint, CGPoint(x: 7.0, y: 4.0))
     }
-    
+
     func testInitializerLineSegment() {
         let l = LineSegment(p0: CGPoint(x: 1.0, y: 2.0), p1: CGPoint(x: 2.0, y: 3.0))
         let c = CubicBezierCurve(lineSegment: l)
@@ -51,7 +51,7 @@ class CubicBezierCurveTests: XCTestCase {
         XCTAssertEqual(c.p2, oneThird * l.p0 + twoThirds * l.p1)
         XCTAssertEqual(c.p3, l.p1)
     }
-    
+
     func testInitializerQuadratic() {
         let q = QuadraticBezierCurve(p0: CGPoint(x: 1.0, y: 1.0), p1: CGPoint(x: 2.0, y: 2.0), p2: CGPoint(x: 3.0, y: 1.0))
         let c = CubicBezierCurve(quadratic: q)
@@ -69,21 +69,21 @@ class CubicBezierCurveTests: XCTestCase {
         XCTAssert((c.p2 - CGPoint(x: sevenThirds, y: fiveThirds)).length < epsilon)
         XCTAssert((c.p3 - CGPoint(x: 3.0, y: 1.0)).length < epsilon)
     }
-    
+
     func testInitializerStartEndMidTStrutLength() {
-        
+
         let epsilon: CGFloat = 0.00001
-        
+
         let start = CGPoint(x: 1.0, y: 1.0)
         let mid = CGPoint(x: 2.0, y: 2.0)
         let end = CGPoint(x: 4.0, y: 0.0)
-        
+
         // first test passing without passing a t or d paramter
         var c = CubicBezierCurve(start: start, end: end, mid: mid)
         XCTAssertEqual(c.compute(0.0), start)
         XCTAssert((c.compute(0.5) - mid).length < epsilon)
         XCTAssertEqual(c.compute(1.0), end)
-       
+
         // now test passing in a manual t and length d
         let t: CGFloat = 7.0 / 9.0
         let d: CGFloat = 1.5
@@ -97,7 +97,7 @@ class CubicBezierCurveTests: XCTestCase {
         let l = (e2 - e1).length
         XCTAssertEqual(l, d * 1.0 / t, accuracy: epsilon)
     }
-    
+
     func testBasicProperties() {
         let c = CubicBezierCurve(p0: CGPoint(x: 1.0, y: 1.0), p1: CGPoint(x: 3.0, y: 2.0), p2: CGPoint(x: 4.0, y: 2.0), p3: CGPoint(x: 6.0, y: 1.0))
         XCTAssert(c.simple)
@@ -115,7 +115,7 @@ class CubicBezierCurveTests: XCTestCase {
         XCTAssertEqual(c.p3, c.endingPoint)
         XCTAssertEqual(c.endingPoint, CGPoint(x: 9.0, y: 8.0))
     }
-    
+
     func testSimple() {
         // create a simple cubic curve (very simple, because it's equal to a line segment)
         let c1 = CubicBezierCurve(p0: CGPoint(x: 1.0, y: 1.0), p1: CGPoint(x: 2.0, y: 2.0), p2: CGPoint(x: 3.0, y: 3.0), p3: CGPoint(x: 4.0, y: 4.0))
@@ -134,7 +134,7 @@ class CubicBezierCurveTests: XCTestCase {
         let c5 = CubicBezierCurve(p0: p, p1: p, p2: p, p3: p)
         XCTAssertTrue(c5.simple)
     }
-    
+
     func testDerivative() {
         let epsilon: CGFloat = 0.00001
         let p0 = CGPoint(x: 1.0, y: 1.0)
@@ -153,7 +153,7 @@ class CubicBezierCurveTests: XCTestCase {
         let t1: CGFloat = 1.0 / 3.0
         let t2: CGFloat = 2.0 / 3.0
         let s = c.split(from: t1, to: t2)
-        XCTAssert(BezierKitTestHelpers.curve(s, matchesCurve: c, overInterval: Interval(start: t1,end: t2), tolerance: epsilon))
+        XCTAssert(BezierKitTestHelpers.curve(s, matchesCurve: c, overInterval: Interval(start: t1, end: t2), tolerance: epsilon))
     }
 
     func testSplitContinuous() {
@@ -162,7 +162,7 @@ class CubicBezierCurveTests: XCTestCase {
         let a: CGFloat = 0.65472931005125345
         let b: CGFloat = 0.73653845530600293
         let c: CGFloat = 1.0
-        let curve = CubicBezierCurve(p0: CGPoint(x: 286.8966218087201, y : 69.11759651620365),
+        let curve = CubicBezierCurve(p0: CGPoint(x: 286.8966218087201, y: 69.11759651620365),
                                      p1: CGPoint(x: 285.7845542083973, y: 69.84970485476842),
                                      p2: CGPoint(x: 284.6698515652002, y: 70.60114443784359),
                                      p3: CGPoint(x: 283.5560914830615, y: 71.34238971309229))
@@ -179,10 +179,10 @@ class CubicBezierCurveTests: XCTestCase {
         let c = CubicBezierCurve(p0: CGPoint(x: 1.0, y: 1.0), p1: CGPoint(x: 3.0, y: 2.0), p2: CGPoint(x: 4.0, y: 2.0), p3: CGPoint(x: 6.0, y: 1.0))
         let t: CGFloat = 0.25
         let (left, right) = c.split(at: t)
-        XCTAssert(BezierKitTestHelpers.curve(left, matchesCurve: c, overInterval: Interval(start: 0,end: t), tolerance: epsilon))
-        XCTAssert(BezierKitTestHelpers.curve(right, matchesCurve: c, overInterval: Interval(start: t,end: 1), tolerance: epsilon))
+        XCTAssert(BezierKitTestHelpers.curve(left, matchesCurve: c, overInterval: Interval(start: 0, end: t), tolerance: epsilon))
+        XCTAssert(BezierKitTestHelpers.curve(right, matchesCurve: c, overInterval: Interval(start: t, end: 1), tolerance: epsilon))
     }
-    
+
     func testBoundingBox() {
         // hits codepath where midpoint pushes up y coordinate of bounding box
         let c1 = CubicBezierCurve(p0: CGPoint(x: 1.0, y: 1.0), p1: CGPoint(x: 3.0, y: 2.0), p2: CGPoint(x: 5.0, y: 2.0), p3: CGPoint(x: 7.0, y: 1.0))
@@ -200,7 +200,7 @@ class CubicBezierCurveTests: XCTestCase {
         let expectedBoundingBox3 = BoundingBox(p1: CGPoint(x: 1.0, y: 1.0),
                                                p2: CGPoint(x: 2.5, y: 1.5625))
         XCTAssertEqual(c3.boundingBox, expectedBoundingBox3)
-        
+
         // bounding box of a degenerate curve made out of a single point
         let p = CGPoint(x: 1.234, y: 2.394)
         let degenerate = CubicBezierCurve(p0: p, p1: p, p2: p, p3: p)
@@ -216,7 +216,7 @@ class CubicBezierCurveTests: XCTestCase {
         XCTAssertEqual(c.compute(0.5), CGPoint(x: 5.0, y: 5.75))
         XCTAssertEqual(c.compute(1.0), CGPoint(x: 7.0, y: 5.0))
     }
-    
+
 // -- MARK: - methods for which default implementations provided by protocol
 
     func testLength() {
@@ -248,9 +248,9 @@ class CubicBezierCurveTests: XCTestCase {
         XCTAssertEqual(xyz[1].count, 1)
         XCTAssertEqual(xyz[1][0], 1.0 / 3.0)
     }
-    
+
 // TODO: we still have some missing unit tests for CubicBezierCurve's API entry points
-    
+
 //    func testHull() {
 //        let l = LineSegment(p0: CGPoint(x: 1.0, y: 2.0), p1: CGPoint(x: 3.0, y: 4.0))
 //        let h = l.hull(0.5)
@@ -431,16 +431,16 @@ class CubicBezierCurveTests: XCTestCase {
             XCTAssertTrue(distance(c2.compute(intersections[i].t2), expectedResults[i]) < epsilon)
         }
     }
-    
+
     func testCubicIntersectsLine() {
         let epsilon: CGFloat = 0.00001
         let c: CubicBezierCurve = CubicBezierCurve(p0: CGPoint(x: -1, y: 0),
                                                    p1: CGPoint(x: -1, y: 1),
-                                                   p2: CGPoint(x:  1, y: -1),
-                                                   p3: CGPoint(x:  1, y: 0))
+                                                   p2: CGPoint(x: 1, y: -1),
+                                                   p3: CGPoint(x: 1, y: 0))
         let l: BezierCurve = LineSegment(p0: CGPoint(x: -2.0, y: 0.0), p1: CGPoint(x: 2.0, y: 0.0))
         let i = c.intersections(with: l)
-        
+
         XCTAssertEqual(i.count, 3)
         XCTAssertEqual(i[0].t2, 0.25, accuracy: epsilon)
         XCTAssertEqual(i[0].t1, 0.0, accuracy: epsilon)
@@ -462,9 +462,9 @@ class CubicBezierCurveTests: XCTestCase {
         XCTAssertEqual(i[0].t1, 1)
         XCTAssertEqual(i[0].t2, 0)
     }
-    
+
     // MARK: -
-    
+
     func testEquatable() {
         let p0 = CGPoint(x: 1.0, y: 2.0)
         let p1 = CGPoint(x: 2.0, y: 3.0)

--- a/BezierKit/BezierKitTests/DrawTests.swift
+++ b/BezierKit/BezierKitTests/DrawTests.swift
@@ -10,25 +10,25 @@ import XCTest
 @testable import BezierKit
 
 class DrawTests: XCTestCase {
-    
+
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
+
     func testHSLToRGB() {
-        
+
         let epsilon: CGFloat = 1.0e-6
-        
+
         var r: CGFloat = 0.0
         var g: CGFloat = 0.0
         var b: CGFloat = 0.0
-        
+
         Draw.HSLToRGB(h: 0.0, s: 1.0, l: 0.5, outR: &r, outG: &g, outB: &b) // pure red
         XCTAssertEqual(r, 1.0, accuracy: epsilon)
         XCTAssertEqual(g, 0.0, accuracy: epsilon)
@@ -43,7 +43,7 @@ class DrawTests: XCTestCase {
         XCTAssertEqual(r, 1.0, accuracy: epsilon)
         XCTAssertEqual(g, 0.0, accuracy: epsilon)
         XCTAssertEqual(b, 1.0, accuracy: epsilon)
-        
+
         Draw.HSLToRGB(h: 0.5, s: 0.0, l: 0.75, outR: &r, outG: &g, outB: &b) // light gray
         XCTAssertEqual(r, 0.75, accuracy: epsilon)
         XCTAssertEqual(g, 0.75, accuracy: epsilon)

--- a/BezierKit/BezierKitTests/FlatnessTests.swift
+++ b/BezierKit/BezierKitTests/FlatnessTests.swift
@@ -32,6 +32,7 @@ class FlatnessTests: XCTestCase {
                                   p3: CGPoint(x: 2, y: 4))
     func testLineSegment() {
         XCTAssertEqual(line.flatness, 0)
+        XCTAssertEqual(line.flatnessSquared, 0)
     }
 
     func testQuadraticBezierCurve() {

--- a/BezierKit/BezierKitTests/LineSegmentTests.swift
+++ b/BezierKit/BezierKitTests/LineSegmentTests.swift
@@ -313,16 +313,14 @@ class LineSegmentTests: XCTestCase {
     }
 
     func testIntersectionsCubicRealWorldIssue() {
+        // this was an issue because if you round t-values that are near zero you will get
+        // cubicCurve.compute(intersections[0].t1).x = 309.5496606404184, which corresponds to t = -3.5242468640577755e-06 on the line (negative! outside the line!)
         let cubicCurve = CubicBezierCurve(p0: CGPoint(x: 301.42017404234923, y: 182.42157189005232),
                                           p1: CGPoint(x: 305.9310607601042, y: 182.30247821176928),
                                           p2: CGPoint(x: 309.72232986751203, y: 185.6785144367646),
                                           p3: CGPoint(x: 310.198127403852, y: 190.08736919846973))
-
         let line = LineSegment(p0: CGPoint(x: 309.54962994198274, y: 187.61824016482512), p1: CGPoint(x: 275.83899279843945, y: 187.61824016482512))
         XCTAssertFalse(cubicCurve.intersects(line))
-
-        // this was an issue because if you round t-values that are near zero you will get
-        // cubicCurve.compute(intersections[0].t1).x = 309.5496606404184, which corresponds to t = -3.5242468640577755e-06 on the line (negative! outside the line!)
     }
 
     func testIntersectionsDegenerateCubic1() {

--- a/BezierKit/BezierKitTests/LineSegmentTests.swift
+++ b/BezierKit/BezierKitTests/LineSegmentTests.swift
@@ -312,6 +312,19 @@ class LineSegmentTests: XCTestCase {
         XCTAssertEqual(i2[2].t2, 0.0, accuracy: epsilon)
     }
 
+    func testIntersectionsCubicRealWorldIssue() {
+        let cubicCurve = CubicBezierCurve(p0: CGPoint(x: 301.42017404234923, y: 182.42157189005232),
+                                          p1: CGPoint(x: 305.9310607601042, y: 182.30247821176928),
+                                          p2: CGPoint(x: 309.72232986751203, y: 185.6785144367646),
+                                          p3: CGPoint(x: 310.198127403852, y: 190.08736919846973))
+
+        let line = LineSegment(p0: CGPoint(x: 309.54962994198274, y: 187.61824016482512), p1: CGPoint(x: 275.83899279843945, y: 187.61824016482512))
+        XCTAssertFalse(cubicCurve.intersects(line))
+
+        // this was an issue because if you round t-values that are near zero you will get
+        // cubicCurve.compute(intersections[0].t1).x = 309.5496606404184, which corresponds to t = -3.5242468640577755e-06 on the line (negative! outside the line!)
+    }
+
     func testIntersectionsDegenerateCubic1() {
         // a special case where the cubic is degenerate (it can actually be described as a quadratic)
         let epsilon: CGFloat = 0.00001

--- a/BezierKit/BezierKitTests/LineSegmentTests.swift
+++ b/BezierKit/BezierKitTests/LineSegmentTests.swift
@@ -15,12 +15,12 @@ class LineSegmentTests: XCTestCase {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
+
     func testInitializerArray() {
         let l = LineSegment(points: [CGPoint(x: 1.0, y: 1.0), CGPoint(x: 3.0, y: 2.0)])
         XCTAssertEqual(l.p0, CGPoint(x: 1.0, y: 1.0))
@@ -36,7 +36,7 @@ class LineSegmentTests: XCTestCase {
         XCTAssertEqual(l.startingPoint, CGPoint(x: 1.0, y: 1.0))
         XCTAssertEqual(l.endingPoint, CGPoint(x: 3.0, y: 2.0))
     }
-    
+
     func testBasicProperties() {
         let l = LineSegment(p0: CGPoint(x: 1.0, y: 1.0), p1: CGPoint(x: 2.0, y: 5.0))
         XCTAssert(l.simple)
@@ -44,7 +44,7 @@ class LineSegmentTests: XCTestCase {
         XCTAssertEqual(l.startingPoint, CGPoint(x: 1.0, y: 1.0))
         XCTAssertEqual(l.endingPoint, CGPoint(x: 2.0, y: 5.0))
     }
-    
+
     func testSetStartEndPoints() {
         var l = LineSegment(p0: CGPoint(x: 5.0, y: 6.0), p1: CGPoint(x: 8.0, y: 7.0))
         l.startingPoint = CGPoint(x: 4.0, y: 5.0)
@@ -54,12 +54,12 @@ class LineSegmentTests: XCTestCase {
         XCTAssertEqual(l.p1, l.endingPoint)
         XCTAssertEqual(l.endingPoint, CGPoint(x: 9.0, y: 8.0))
     }
-    
+
     func testDerivative() {
         let l = LineSegment(p0: CGPoint(x: 1.0, y: 1.0), p1: CGPoint(x: 3.0, y: 2.0))
         XCTAssertEqual(l.derivative(0.23), CGPoint(x: 2.0, y: 1.0))
     }
-    
+
     func testSplitFromTo() {
         let l = LineSegment(p0: CGPoint(x: 1.0, y: 1.0), p1: CGPoint(x: 4.0, y: 7.0))
         let t1: CGFloat = 1.0 / 3.0
@@ -67,38 +67,38 @@ class LineSegmentTests: XCTestCase {
         let s = l.split(from: t1, to: t2)
         XCTAssertEqual(s, LineSegment(p0: CGPoint(x: 2.0, y: 3.0), p1: CGPoint(x: 3.0, y: 5.0)))
     }
-    
+
     func testSplitAt() {
         let l = LineSegment(p0: CGPoint(x: 1.0, y: 1.0), p1: CGPoint(x: 3.0, y: 5.0))
         let (left, right) = l.split(at: 0.5)
         XCTAssertEqual(left, LineSegment(p0: CGPoint(x: 1.0, y: 1.0), p1: CGPoint(x: 2.0, y: 3.0)))
         XCTAssertEqual(right, LineSegment(p0: CGPoint(x: 2.0, y: 3.0), p1: CGPoint(x: 3.0, y: 5.0)))
     }
-    
+
     func testBoundingBox() {
         let l = LineSegment(p0: CGPoint(x: 3.0, y: 5.0), p1: CGPoint(x: 1.0, y: 3.0))
         XCTAssertEqual(l.boundingBox, BoundingBox(p1: CGPoint(x: 1.0, y: 3.0), p2: CGPoint(x: 3.0, y: 5.0)))
     }
-    
+
     func testCompute() {
         let l = LineSegment(p0: CGPoint(x: 3.0, y: 5.0), p1: CGPoint(x: 1.0, y: 3.0))
         XCTAssertEqual(l.compute(0.0), CGPoint(x: 3.0, y: 5.0))
         XCTAssertEqual(l.compute(0.5), CGPoint(x: 2.0, y: 4.0))
         XCTAssertEqual(l.compute(1.0), CGPoint(x: 1.0, y: 3.0))
     }
-    
+
     func testLength() {
         let l = LineSegment(p0: CGPoint(x: 1.0, y: 2.0), p1: CGPoint(x: 4.0, y: 6.0))
         XCTAssertEqual(l.length(), 5.0)
     }
-    
+
     func testExtrema() {
         let l = LineSegment(p0: CGPoint(x: 1.0, y: 2.0), p1: CGPoint(x: 4.0, y: 6.0))
         let (xyz, values) = l.extrema()
         XCTAssertTrue(xyz.isEmpty)
         XCTAssertTrue(values.isEmpty)
     }
-    
+
     func testHull() {
         let l = LineSegment(p0: CGPoint(x: 1.0, y: 2.0), p1: CGPoint(x: 3.0, y: 4.0))
         let h = l.hull(0.5)
@@ -107,7 +107,7 @@ class LineSegmentTests: XCTestCase {
         XCTAssertEqual(h[1], CGPoint(x: 3.0, y: 4.0))
         XCTAssertEqual(h[2], CGPoint(x: 2.0, y: 3.0))
     }
-    
+
     func testNormal() {
         let l = LineSegment(p0: CGPoint(x: 1.0, y: 2.0), p1: CGPoint(x: 5.0, y: 6.0))
         let n1 = l.normal(0.0)
@@ -117,7 +117,7 @@ class LineSegmentTests: XCTestCase {
         XCTAssertEqual(n1, n2)
         XCTAssertEqual(n2, n3)
     }
-    
+
     func testReduce() {
         let l = LineSegment(p0: CGPoint(x: 1.0, y: 2.0), p1: CGPoint(x: 5.0, y: 6.0))
         let r = l.reduce() // reduce should just return the original line back
@@ -135,7 +135,7 @@ class LineSegmentTests: XCTestCase {
     }
 
     // -- MARK: - line-line intersection tests
-    
+
     func testIntersectionsLineYesInsideInterval() {
         // a normal line-line intersection that happens in the middle of a line
         let l1 = LineSegment(p0: CGPoint(x: 1.0, y: 2.0), p1: CGPoint(x: 7.0, y: 8.0))
@@ -145,7 +145,7 @@ class LineSegmentTests: XCTestCase {
         XCTAssertEqual(i[0].t1, 1.0 / 6.0)
         XCTAssertEqual(i[0].t2, 1.0 / 4.0)
     }
-    
+
     func testIntersectionsLineNoOutsideInterval1() {
         // two lines that do not intersect because the intersection happens outside the line-segment
         let l1 = LineSegment(p0: CGPoint(x: 1.0, y: 0.0), p1: CGPoint(x: 1.0, y: 2.0))
@@ -153,7 +153,7 @@ class LineSegmentTests: XCTestCase {
         let i = l1.intersections(with: l2)
         XCTAssert(i.isEmpty)
     }
-    
+
     func testIntersectionsLineNoOutsideInterval2() {
         // two lines that do not intersect because the intersection happens outside the *other* line segment
         let l1 = LineSegment(p0: CGPoint(x: 1.0, y: 0.0), p1: CGPoint(x: 1.0, y: 2.0))
@@ -161,7 +161,7 @@ class LineSegmentTests: XCTestCase {
         let i = l1.intersections(with: l2)
         XCTAssert(i.isEmpty)
     }
-    
+
     func testIntersectionsLineYesEdge1() {
         // two lines that intersect on the 1st line's edge
         let l1 = LineSegment(p0: CGPoint(x: 1.0, y: 0.0), p1: CGPoint(x: 1.0, y: 2.0))
@@ -171,7 +171,7 @@ class LineSegmentTests: XCTestCase {
         XCTAssertEqual(i[0].t1, 0.5)
         XCTAssertEqual(i[0].t2, 1.0)
     }
-    
+
     func testIntersectionsLineYesEdge2() {
         // two lines that intersect on the 2nd line's edge
         let l1 = LineSegment(p0: CGPoint(x: 1.0, y: 0.0), p1: CGPoint(x: 1.0, y: 2.0))
@@ -191,7 +191,7 @@ class LineSegmentTests: XCTestCase {
         XCTAssertEqual(i[0].t1, 0.0)
         XCTAssertEqual(i[0].t2, 1.0)
     }
-    
+
     func testIntersectionsLineYesLineEnd() {
         // two lines that intersect at the end of the first line
         let l1 = LineSegment(p0: CGPoint(x: 1.0, y: 0.0), p1: CGPoint(x: 2.0, y: 1.0))
@@ -201,7 +201,7 @@ class LineSegmentTests: XCTestCase {
         XCTAssertEqual(i[0].t1, 1.0)
         XCTAssertEqual(i[0].t2, 0.0)
     }
-    
+
     func testIntersectionsLineAsCurve() {
         // ensure that intersects(curve:) calls into the proper implementation
         let l1: LineSegment = LineSegment(p0: CGPoint(x: 0.0, y: 0.0), p1: CGPoint(x: 1.0, y: 1.0))
@@ -210,15 +210,15 @@ class LineSegmentTests: XCTestCase {
         XCTAssertEqual(i1.count, 1)
         XCTAssertEqual(i1[0].t1, 0.5)
         XCTAssertEqual(i1[0].t2, 0.5)
-        
+
         let i2 = l2.intersections(with: l1)
         XCTAssertEqual(i2.count, 1)
         XCTAssertEqual(i2[0].t1, 0.5)
         XCTAssertEqual(i2[0].t2, 0.5)
     }
-    
+
     func testIntersectionsLineNoParallel() {
-        
+
         // this is a special case where determinant is zero
         let l1 = LineSegment(p0: CGPoint(x: -2.0, y: -1.0), p1: CGPoint(x: 2.0, y: 1.0))
         let l2 = LineSegment(p0: CGPoint(x: -4.0, y: -1.0), p1: CGPoint(x: 4.0, y: 3.0))
@@ -237,9 +237,9 @@ class LineSegmentTests: XCTestCase {
         let i3 = l5.intersections(with: l6)
         XCTAssertTrue(i3.isEmpty)
     }
-    
+
     // -- MARK: - line-curve intersection tests
-    
+
     func testIntersectionsQuadratic() {
         // we mostly just care that we call into the proper implementation and that the results are ordered correctly
         // q is a quadratic where y(x) = 2 - 2(x-1)^2
@@ -271,7 +271,7 @@ class LineSegmentTests: XCTestCase {
         XCTAssertEqual(i2[1].t2, r1 / 2.0, accuracy: epsilon)
         XCTAssert((l2.compute(i2[1].t1) - q.compute(i2[1].t2)).length < epsilon)
     }
-    
+
     func testIntersectionsQuadraticSpecialCase() {
         // this is case that failed in the real-world
         let l = LineSegment(p0: CGPoint(x: -1, y: 0), p1: CGPoint(x: 1, y: 0))
@@ -281,17 +281,17 @@ class LineSegmentTests: XCTestCase {
         XCTAssertEqual(i.first?.t1, 0.5)
         XCTAssertEqual(i.first?.t2, 0)
     }
-    
+
     func testIntersectionsCubic() {
         // we mostly just care that we call into the proper implementation and that the results are ordered correctly
         let epsilon: CGFloat = 0.00001
         let c: CubicBezierCurve = CubicBezierCurve(p0: CGPoint(x: -1, y: 0),
                                                    p1: CGPoint(x: -1, y: 1),
-                                                   p2: CGPoint(x:  1, y: -1),
-                                                   p3: CGPoint(x:  1, y: 0))
+                                                   p2: CGPoint(x: 1, y: -1),
+                                                   p3: CGPoint(x: 1, y: 0))
         let l1: LineSegment = LineSegment(p0: CGPoint(x: -2.0, y: 0.0), p1: CGPoint(x: 2.0, y: 0.0))
         let i1 = l1.intersections(with: c)
-      
+
         XCTAssertEqual(i1.count, 3)
         XCTAssertEqual(i1[0].t1, 0.25, accuracy: epsilon)
         XCTAssertEqual(i1[0].t2, 0.0, accuracy: epsilon)
@@ -311,7 +311,7 @@ class LineSegmentTests: XCTestCase {
         XCTAssertEqual(i2[2].t1, 0.75, accuracy: epsilon)
         XCTAssertEqual(i2[2].t2, 0.0, accuracy: epsilon)
     }
-        
+
     func testIntersectionsDegenerateCubic1() {
         // a special case where the cubic is degenerate (it can actually be described as a quadratic)
         let epsilon: CGFloat = 0.00001
@@ -321,12 +321,12 @@ class LineSegmentTests: XCTestCase {
                                                    p1: CGPoint(x: fiveThirds, y: fiveThirds),
                                                    p2: CGPoint(x: sevenThirds, y: fiveThirds),
                                                    p3: CGPoint(x: 3.0, y: 1.0))
-        let l = LineSegment(p0: CGPoint(x:1.0, y: 1.1), p1: CGPoint(x: 3.0, y: 1.1))
+        let l = LineSegment(p0: CGPoint(x: 1.0, y: 1.1), p1: CGPoint(x: 3.0, y: 1.1))
         let i = l.intersections(with: c)
         XCTAssertEqual(i.count, 2)
         XCTAssert(BezierKitTestHelpers.intersections(i, betweenCurve: l, andOtherCurve: c, areWithinTolerance: epsilon))
     }
-    
+
     func testIntersectionsDegenerateCubic2() {
         // a special case where the cubic is degenerate (it can actually be described as a line)
         let epsilon: CGFloat = 0.00001
@@ -334,7 +334,7 @@ class LineSegmentTests: XCTestCase {
                                                    p1: CGPoint(x: 2.0, y: 2.0),
                                                    p2: CGPoint(x: 3.0, y: 3.0),
                                                    p3: CGPoint(x: 4.0, y: 4.0))
-        let l = LineSegment(p0: CGPoint(x:1.0, y: 2.0), p1: CGPoint(x: 4.0, y: 2.0))
+        let l = LineSegment(p0: CGPoint(x: 1.0, y: 2.0), p1: CGPoint(x: 4.0, y: 2.0))
         let i = l.intersections(with: c)
         XCTAssertEqual(i.count, 1)
         XCTAssert(BezierKitTestHelpers.intersections(i, betweenCurve: l, andOtherCurve: c, areWithinTolerance: epsilon))
@@ -349,7 +349,7 @@ class LineSegmentTests: XCTestCase {
         XCTAssertEqual(i.first?.t1, 0.5)
         XCTAssertEqual(i.first?.t2, 0)
     }
-    
+
     func testIntersectionsCubicRootsEdgeCase() {
         // this data caused issues in practice because because 'd' in the roots calculation is very near, but not exactly, zero.
         let c = CubicBezierCurve(p0: CGPoint(x: 201.48419096574196, y: 570.7720830272123),
@@ -371,9 +371,9 @@ class LineSegmentTests: XCTestCase {
         let i = l.intersections(with: c)
         XCTAssertEqual(i, [])
     }
-    
+
     // MARK: -
-    
+
     func testEquatable() {
         let l1 = LineSegment(p0: CGPoint(x: 1.0, y: 2.0), p1: CGPoint(x: 3.0, y: 4.0))
         let l2 = LineSegment(p0: CGPoint(x: 1.0, y: 3.0), p1: CGPoint(x: 3.0, y: 4.0))

--- a/BezierKit/BezierKitTests/LineSegmentTests.swift
+++ b/BezierKit/BezierKitTests/LineSegmentTests.swift
@@ -313,6 +313,7 @@ class LineSegmentTests: XCTestCase {
     }
 
     func testIntersectionsCubicRealWorldIssue() {
+        guard MemoryLayout<CGFloat>.size > 4 else { return } // not enough precision in points for test to be valid
         // this was an issue because if you round t-values that are near zero you will get
         // cubicCurve.compute(intersections[0].t1).x = 309.5496606404184, which corresponds to t = -3.5242468640577755e-06 on the line (negative! outside the line!)
         let cubicCurve = CubicBezierCurve(p0: CGPoint(x: 301.42017404234923, y: 182.42157189005232),
@@ -373,6 +374,7 @@ class LineSegmentTests: XCTestCase {
     }
     
     func testIntersectionsCubicRootsEdgeCase2() {
+        guard MemoryLayout<CGFloat>.size > 4 else { return } // not enough precision in points for test to be valid
         // this data caused issues in practice because because the discriminant in the roots calculation is very near zero
         let line = LineSegment(p0 : CGPoint(x: 503.31162501468725, y: 766.9016671863201),
                                p1: CGPoint(x: 504.2124710211739, y: 767.3358059574488))

--- a/BezierKit/BezierKitTests/LineSegmentTests.swift
+++ b/BezierKit/BezierKitTests/LineSegmentTests.swift
@@ -350,7 +350,7 @@ class LineSegmentTests: XCTestCase {
         XCTAssertEqual(i.first?.t2, 0)
     }
 
-    func testIntersectionsCubicRootsEdgeCase() {
+    func testIntersectionsCubicRootsEdgeCase1() {
         // this data caused issues in practice because because 'd' in the roots calculation is very near, but not exactly, zero.
         let c = CubicBezierCurve(p0: CGPoint(x: 201.48419096574196, y: 570.7720830272123),
                                  p1: CGPoint(x: 202.27135851996428, y: 570.7720830272123),
@@ -359,6 +359,22 @@ class LineSegmentTests: XCTestCase {
         let l = LineSegment(p0: CGPoint(x: 200.05889802679428, y: 572.1973759661599), p1: CGPoint(x: 201.48419096574196, y: 573.6226689051076))
         let i = l.intersections(with: c)
         XCTAssertEqual(i, [])
+    }
+    
+    func testIntersectionsCubicRootsEdgeCase2() {
+        // this data caused issues in practice because because the discriminant in the roots calculation is very near zero
+        let line = LineSegment(p0 : CGPoint(x: 503.31162501468725, y: 766.9016671863201),
+                               p1: CGPoint(x: 504.2124710211739, y: 767.3358059574488))
+        let curve = CubicBezierCurve(p0: CGPoint(x: 505.16132944417086, y: 779.6305912206088),
+                                     p1: CGPoint(x: 503.19076843492786, y: 767.0872665416827),
+                                     p2: CGPoint(x: 503.3761460381431, y: 766.7563954079359),
+                                     p3: CGPoint(x: 503.3060153966664, y: 766.9140612367046))
+        let i = line.intersections(with: curve)
+        XCTAssertEqual(i.count, 2)
+        i.forEach {
+            let d = distance(line.compute($0.t1), curve.compute($0.t2))
+            XCTAssertTrue(d < 1.0e-4, "distance line.compute(\($0.t1)) to curve.compute(\($0.t2)) = \(d)")
+        }
     }
 
     func testIntersectionsCubicDegenerate() {

--- a/BezierKit/BezierKitTests/Path+DataTests.swift
+++ b/BezierKit/BezierKitTests/Path+DataTests.swift
@@ -39,7 +39,7 @@ fileprivate extension CGPath {
         var elements: [CGPathElementRecord] = []
     }
     var elements: [CGPathElementRecord] {
-        func elementGetterApplierFunction(_ info: UnsafeMutableRawPointer?, _ element: UnsafePointer<CGPathElement>) -> Void {
+        func elementGetterApplierFunction(_ info: UnsafeMutableRawPointer?, _ element: UnsafePointer<CGPathElement>) {
             let context = info!.assumingMemoryBound(to: ElementGetterContext.self).pointee
             context.elements.append(CGPathElementRecord(element.pointee))
         }
@@ -54,7 +54,7 @@ class PathDataTests: XCTestCase {
     private func pathHasEqualElementsToCGPath(_ path1: Path, _ path2: CGPath) -> Bool {
         return cgPathsHaveEqualCGPathElements(path1.cgPath, path2)
     }
-        
+
     private func cgPathsHaveEqualCGPathElements(_ path1: CGPath, _ path2: CGPath) -> Bool {
         // checks that the CGPathElements that make up the paths are exactly equal
         // unfortunately we cannot just check path1 == path2 because CGPath.isRect can differ even if the underlying data is the same

--- a/BezierKit/BezierKitTests/Path+DataTests.swift
+++ b/BezierKit/BezierKitTests/Path+DataTests.swift
@@ -52,7 +52,7 @@ fileprivate extension CGPath {
 class PathDataTests: XCTestCase {
 
     private func pathHasEqualElementsToCGPath(_ path1: Path, _ path2: CGPath) -> Bool {
-        return cgPathsHaveEqualCGPathElements(path1.cgPath, path2)
+        return cgPathsHaveEqualCGPathElements(Path(data: path1.data)!.cgPath, path2)
     }
 
     private func cgPathsHaveEqualCGPathElements(_ path1: CGPath, _ path2: CGPath) -> Bool {
@@ -147,6 +147,9 @@ class PathDataTests: XCTestCase {
         cgPath.move(to: CGPoint(x: 1, y: 2))
         cgPath.move(to: CGPoint(x: 2, y: 3))
         cgPath.move(to: CGPoint(x: 3, y: 4))
+
+        let what = Path(cgPath: cgPath)
+
         XCTAssertTrue(pathHasEqualElementsToCGPath(Path(cgPath: cgPath), cgPath))
         cgPath.addLine(to: CGPoint(x: 4, y: 5))
         XCTAssertTrue(pathHasEqualElementsToCGPath(Path(cgPath: cgPath), cgPath))

--- a/BezierKit/BezierKitTests/PathComponentTests.swift
+++ b/BezierKit/BezierKitTests/PathComponentTests.swift
@@ -10,20 +10,20 @@ import XCTest
 @testable import BezierKit
 
 class PathComponentTests: XCTestCase {
-    
+
     let line1 = LineSegment(p0: CGPoint(x: 1.0, y: 2.0), p1: CGPoint(x: 5.0, y: 5.0))   // length = 5
     let line2 = LineSegment(p0: CGPoint(x: 5.0, y: 5.0), p1: CGPoint(x: 13.0, y: -1.0)) // length = 10
-    
+
     func testLength() {
         let p = PathComponent(curves: [line1, line2])
         XCTAssertEqual(p.length, 15.0) // sum of two lengths
     }
-    
+
     func testBoundingBox() {
         let p = PathComponent(curves: [line1, line2])
         XCTAssertEqual(p.boundingBox, BoundingBox(min: CGPoint(x: 1.0, y: -1.0), max: CGPoint(x: 13.0, y: 5.0))) // just the union of the two bounding boxes
     }
-    
+
     func testOffset() {
         // construct a PathComponent from a split cubic
         let q = QuadraticBezierCurve(p0: CGPoint(x: 0.0, y: 0.0), p1: CGPoint(x: 2.0, y: 1.0), p2: CGPoint(x: 4.0, y: 0.0))
@@ -31,12 +31,12 @@ class PathComponentTests: XCTestCase {
         let p = PathComponent(curves: [ql, qr])
         // test that offset gives us the same result as offsetting the split segments
         let pOffset = p.offset(distance: 1)
-        
+
         for (c1, c2) in zip(pOffset.curves, ql.offset(distance: 1) + qr.offset(distance: 1)) {
             XCTAssert(c1 == c2)
         }
     }
-    
+
     private let p1 = CGPoint(x: 0.0, y: 1.0)
     private let p2 = CGPoint(x: 2.0, y: 1.0)
     private let p3 = CGPoint(x: 2.5, y: 0.5)
@@ -45,18 +45,18 @@ class PathComponentTests: XCTestCase {
     private let p6 = CGPoint(x: -0.5, y: 0.25)
     private let p7 = CGPoint(x: -0.5, y: 0.75)
     private let p8 = CGPoint(x: 0.0, y: 1.0)
-    
+
     func testEquatable() {
-    
+
         let l1 = LineSegment(p0: p1, p1: p2)
         let q1 = QuadraticBezierCurve(p0: p2, p1: p3, p2: p4)
         let l2 = LineSegment(p0: p4, p1: p5)
         let c1 = CubicBezierCurve(p0: p5, p1: p6, p2: p7, p3: p8)
-        
+
         let pathComponent1 = PathComponent(curves: [l1, q1, l2, c1])
         let pathComponent2 = PathComponent(curves: [l1, q1, l2])
         let pathComponent3 = PathComponent(curves: [l1, q1, l2, c1])
-        
+
         var altC1 = c1
         altC1.p2.x = -0.25
         let pathComponent4 = PathComponent(curves: [l1, q1, l2, altC1])
@@ -65,14 +65,14 @@ class PathComponentTests: XCTestCase {
         XCTAssertEqual(pathComponent1, pathComponent3)    // same path elements means equal
         XCTAssertNotEqual(pathComponent1, pathComponent4) // pathComponent4 has an element with a modified path
     }
-    
+
     func testIsEqual() {
-        
+
         let l1 = LineSegment(p0: p1, p1: p2)
         let q1 = QuadraticBezierCurve(p0: p2, p1: p3, p2: p4)
         let l2 = LineSegment(p0: p4, p1: p5)
         let c1 = CubicBezierCurve(p0: p5, p1: p6, p2: p7, p3: p8)
-        
+
         let pathComponent1 = PathComponent(curves: [l1, q1, l2, c1])
         let pathComponent2 = PathComponent(curves: [l1, q1, l2, c1])
         var altC1 = c1
@@ -80,7 +80,7 @@ class PathComponentTests: XCTestCase {
         let pathComponent3 = PathComponent(curves: [l1, q1, l2, altC1])
 
         let string = "hello!" as NSString
-        
+
         XCTAssertFalse(pathComponent1.isEqual(string))
         XCTAssertFalse(pathComponent1.isEqual(nil))
         XCTAssertTrue(pathComponent1.isEqual(pathComponent1))
@@ -175,4 +175,3 @@ class PathComponentTests: XCTestCase {
         XCTAssertEqual(arrayByEnumerating(component: circlePathComponent, includeControlPoints: true), circlePathComponent.points)
     }
 }
-

--- a/BezierKit/BezierKitTests/PathTests.swift
+++ b/BezierKit/BezierKitTests/PathTests.swift
@@ -575,6 +575,8 @@ class PathTests: XCTestCase {
         XCTAssertTrue(a.contains(point, using: rule))
         XCTAssertTrue(b.contains(point, using: rule))
         XCTAssertTrue(result.contains(point, using: rule), "a union b should contain point that is in both a and b")
+        XCTAssertTrue(result.boundingBox.cgRect.insetBy(dx: -1, dy: -1).contains(a.boundingBox.cgRect), "resulting bounding box should contain a.boundingBox")
+        XCTAssertTrue(result.boundingBox.cgRect.insetBy(dx: -1, dy: -1).contains(b.boundingBox.cgRect), "resulting bounding box should contain b.boundingBox")
     }
 
     func testIntersecting() {

--- a/BezierKit/BezierKitTests/PathTests.swift
+++ b/BezierKit/BezierKitTests/PathTests.swift
@@ -528,6 +528,56 @@ class PathTests: XCTestCase {
         )
     }
 
+    func testUnionRealWorldEdgeCase() {
+        let a = { () -> Path in
+            let cgPath = CGMutablePath()
+            cgPath.move(to: CGPoint(x: 310.198127403852, y: 190.08736919846973))
+            cgPath.addCurve(to: CGPoint(x: 309.1982933716744, y: 195.17240727745877),
+                control1: CGPoint(x: 310.390629965343, y: 191.78584973769978),
+                control2: CGPoint(x: 310.0800866088565, y: 193.5583513843498))
+            cgPath.addCurve(to: CGPoint(x: 297.52638944557776, y: 198.59685279578636),
+                control1: CGPoint(x: 306.9208206199371, y: 199.34114906559483),
+                control2: CGPoint(x: 301.6951312337138, y: 200.87432554752368))
+            cgPath.addCurve(to: CGPoint(x: 293.06807628308206, y: 191.637728075906),
+                control1: CGPoint(x: 294.8541298755864, y: 197.13694026929096),
+                control2: CGPoint(x: 293.26485189217163, y: 194.46557442730858))
+            cgPath.addCurve(to: CGPoint(x: 293.0490061981148, y: 191.24674708897507),
+                control1: CGPoint(x: 293.05884562618036, y: 191.50820426365925),
+                control2: CGPoint(x: 293.0524676850055, y: 191.37785711483136))
+            cgPath.addCurve(to: CGPoint(x: 301.42017404234923, y: 182.42157189005232),
+                control1: CGPoint(x: 292.9236355289621, y: 186.49810808117778),
+                control2: CGPoint(x: 296.67153503455194, y: 182.546942559205))
+            cgPath.addCurve(to: CGPoint(x: 310.198127403852, y: 190.08736919846973),
+                control1: CGPoint(x: 305.9310607601042, y: 182.30247821176928),
+                control2: CGPoint(x: 309.72232986751203, y: 185.6785144367646))
+            return Path(cgPath: cgPath)
+        }()
+
+        let b = { () -> Path in
+            let cgPath = CGMutablePath()
+            cgPath.move(to: CGPoint(x: 309.5688043100249, y: 187.66446326122298))
+            cgPath.addCurve(to: CGPoint(x: 304.8877314421214, y: 198.89156106846605),
+                            control1: CGPoint(x: 311.37643918302956, y: 192.05738329201742),
+                            control2: CGPoint(x: 309.28065147291585, y: 197.0839261954614))
+            cgPath.addCurve(to: CGPoint(x: 293.6606336348783, y: 194.21048820056248),
+                            control1: CGPoint(x: 300.4948114113269, y: 200.6991959414707),
+                            control2: CGPoint(x: 295.46826850788295, y: 198.60340823135695))
+            cgPath.addCurve(to: CGPoint(x: 298.3417065027818, y: 182.98339039331944),
+                            control1: CGPoint(x: 291.85299876187366, y: 189.81756816976807),
+                            control2: CGPoint(x: 293.9487864719874, y: 184.79102526632408))
+            cgPath.addCurve(to: CGPoint(x: 309.5688043100249, y: 187.66446326122298),
+                            control1: CGPoint(x: 302.7346265335763, y: 181.1757555203148),
+                            control2: CGPoint(x: 307.76116943702027, y: 183.2715432304285))
+            return Path(cgPath: cgPath)
+        }()
+        let result = a.union(b, accuracy: 1.0e-4)!
+        let point = CGPoint(x: 302, y: 191)
+        let rule = PathFillRule.evenOdd
+        XCTAssertTrue(a.contains(point, using: rule))
+        XCTAssertTrue(b.contains(point, using: rule))
+        XCTAssertTrue(result.contains(point, using: rule), "a union b should contain point that is in both a and b")
+    }
+
     func testIntersecting() {
         let expectedResult = Path(components: [PathComponent(curves:
             [

--- a/BezierKit/BezierKitTests/PathTests.swift
+++ b/BezierKit/BezierKitTests/PathTests.swift
@@ -529,7 +529,7 @@ class PathTests: XCTestCase {
     }
 
     func testUnionRealWorldEdgeCase() {
-        let a = { () -> Path in
+        let a = {() -> Path in
             let cgPath = CGMutablePath()
             cgPath.move(to: CGPoint(x: 310.198127403852, y: 190.08736919846973))
             cgPath.addCurve(to: CGPoint(x: 309.1982933716744, y: 195.17240727745877),
@@ -552,8 +552,7 @@ class PathTests: XCTestCase {
                 control2: CGPoint(x: 309.72232986751203, y: 185.6785144367646))
             return Path(cgPath: cgPath)
         }()
-
-        let b = { () -> Path in
+        let b = {() -> Path in
             let cgPath = CGMutablePath()
             cgPath.move(to: CGPoint(x: 309.5688043100249, y: 187.66446326122298))
             cgPath.addCurve(to: CGPoint(x: 304.8877314421214, y: 198.89156106846605),

--- a/BezierKit/BezierKitTests/PathTests.swift
+++ b/BezierKit/BezierKitTests/PathTests.swift
@@ -748,10 +748,6 @@ class PathTests: XCTestCase {
     }
 
     func testCrossingsRemovedAnotherRealWorldCase() {
-
-        // TODO: re-enable this unit test -- I was never able to get this to pass
-        // (must be re-enabled in Mac and iOS test suite separately)
-
         let cgPath = CGMutablePath()
         let start = CGPoint(x: 503.3060153966664, y: 766.9140612367046)
         cgPath.move(to: start)

--- a/BezierKit/BezierKitTests/PathTests.swift
+++ b/BezierKit/BezierKitTests/PathTests.swift
@@ -529,6 +529,7 @@ class PathTests: XCTestCase {
     }
 
     func testUnionRealWorldEdgeCase() {
+        guard MemoryLayout<CGFloat>.size > 4 else { return } // not enough precision in points for test to be valid
         let a = {() -> Path in
             let cgPath = CGMutablePath()
             cgPath.move(to: CGPoint(x: 310.198127403852, y: 190.08736919846973))
@@ -734,6 +735,7 @@ class PathTests: XCTestCase {
 
     func testCrossingsRemovedEdgeCaseInnerLoop() {
 
+        // the path is a box with a loop that begins at (2,0), touches the top of the box at (2,2) exactly tangent
         // this tests an edge case of crossingsRemoved() when vertices of the path are exactly equal
         // the path does a complete loop in the middle
 

--- a/BezierKit/BezierKitTests/PathTests.swift
+++ b/BezierKit/BezierKitTests/PathTests.swift
@@ -11,42 +11,42 @@ import CoreGraphics
 @testable import BezierKit
 
 class PathTests: XCTestCase {
-    
+
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
+
     func testInitCGPathEmpty() {
         // trivial test of an empty path
         let path = Path(cgPath: CGMutablePath())
         XCTAssert(path.components.isEmpty)
     }
-    
+
     func testInitCGPathRect() {
-        
+
         // simple test of a rectangle (note that this CGPath uses a moveTo())
         let rect = CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: 1, height: 2))
         let cgPath1 = CGPath(rect: rect, transform: nil)
         let path1 = Path(cgPath: cgPath1)
-        
+
         let p1 = CGPoint(x: 0.0, y: 0.0)
         let p2 = CGPoint(x: 1.0, y: 0.0)
         let p3 = CGPoint(x: 1.0, y: 2.0)
         let p4 = CGPoint(x: 0.0, y: 2.0)
-        
+
         XCTAssertEqual(path1.components.count, 1)
         XCTAssertEqual(path1.components[0].element(at: 0) as! LineSegment, LineSegment(p0: p1, p1: p2))
         XCTAssertEqual(path1.components[0].element(at: 1) as! LineSegment, LineSegment(p0: p2, p1: p3))
         XCTAssertEqual(path1.components[0].element(at: 2) as! LineSegment, LineSegment(p0: p3, p1: p4))
         XCTAssertEqual(path1.components[0].element(at: 3) as! LineSegment, LineSegment(p0: p4, p1: p1))
     }
-    
+
     func testInitCGPathEllipse() {
         // test of a ellipse (4 cubic curves)
         let rect = CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: 1, height: 2))
@@ -57,7 +57,7 @@ class PathTests: XCTestCase {
         let p2 = CGPoint(x: 0.5, y: 2.0)
         let p3 = CGPoint(x: 0.0, y: 1.0)
         let p4 = CGPoint(x: 0.5, y: 0.0)
-        
+
         XCTAssertEqual(path2.components.count, 1)
         XCTAssertEqual(path2.components[0].elementCount, 4)
         XCTAssertEqual(path2.components[0].element(at: 0).startingPoint, p1)
@@ -69,31 +69,31 @@ class PathTests: XCTestCase {
         XCTAssertEqual(path2.components[0].element(at: 2).endingPoint, p4)
         XCTAssertEqual(path2.components[0].element(at: 3).endingPoint, p1)
     }
-        
+
     func testInitCGPathQuads() {
         // test of a rect with some quad curves
         let cgPath3 = CGMutablePath()
-        
+
         let p1 = CGPoint(x: 0.0, y: 1.0)
         let p2 = CGPoint(x: 2.0, y: 1.0)
         let p3 = CGPoint(x: 3.0, y: 0.5)
         let p4 = CGPoint(x: 2.0, y: 0.0)
         let p5 = CGPoint(x: 0.0, y: 0.0)
         let p6 = CGPoint(x: -1.0, y: 0.5)
-        
+
         cgPath3.move(to: p1)
         cgPath3.addLine(to: p2)
         cgPath3.addQuadCurve(to: p4, control: p3)
         cgPath3.addLine(to: p5)
         cgPath3.addQuadCurve(to: p1, control: p6)
         cgPath3.closeSubpath()
-        
+
         let path3 = Path(cgPath: cgPath3)
         XCTAssertEqual(path3.components.count, 1)
         XCTAssertEqual(path3.components[0].elementCount, 4)
         XCTAssertEqual(path3.components[0].element(at: 1) as! QuadraticBezierCurve, QuadraticBezierCurve(p0: p2, p1: p3, p2: p4))
     }
-    
+
     func testInitCGPathMultiplecomponents() {
         // test of 2 line segments where each segment is started with a moveTo
         // this tests multiple components and starting new paths with moveTo instead of closePath
@@ -102,12 +102,12 @@ class PathTests: XCTestCase {
         let p2 = CGPoint(x: 3.0, y: 5.0)
         let p3 = CGPoint(x: -4.0, y: -1.0)
         let p4 = CGPoint(x: 5.0, y: 3.0)
-        
+
         cgPath4.move(to: p1)
         cgPath4.addLine(to: p2)
         cgPath4.move(to: p3)
         cgPath4.addLine(to: p4)
-        
+
         let path4 = Path(cgPath: cgPath4)
         XCTAssertEqual(path4.components.count, 2)
         XCTAssertEqual(path4.components[0].elementCount, 1)
@@ -115,16 +115,16 @@ class PathTests: XCTestCase {
         XCTAssertEqual(path4.components[0].element(at: 0) as! LineSegment, LineSegment(p0: p1, p1: p2))
         XCTAssertEqual(path4.components[1].element(at: 0) as! LineSegment, LineSegment(p0: p3, p1: p4))
     }
-    
+
     func testIntersections() {
         let circleCGPath = CGPath(ellipseIn: CGRect(x: 2.0, y: 3.0, width: 2.0, height: 2.0), transform: nil)
         let circlePath = Path(cgPath: circleCGPath) // a circle centered at (3, 4) with radius 2
-        
+
         let rectangleCGPath = CGPath(rect: CGRect(x: 3.0, y: 4.0, width: 2.0, height: 2.0), transform: nil)
         let rectanglePath = Path(cgPath: rectangleCGPath)
-        
+
         let intersections = rectanglePath.intersections(with: circlePath).map { rectanglePath.point(at: $0.indexedPathLocation1 ) }
-        
+
         XCTAssertEqual(intersections.count, 2)
         XCTAssert(intersections.contains(CGPoint(x: 4.0, y: 4.0)))
         XCTAssert(intersections.contains(CGPoint(x: 3.0, y: 5.0)))
@@ -135,7 +135,7 @@ class PathTests: XCTestCase {
         XCTAssertEqual(emptyPath.selfIntersections(), [])
         XCTAssertFalse(emptyPath.selfIntersects())
     }
-    
+
     func testSelfIntersectionsSingleComponentPath() {
         let singleComponentPath = { () -> Path in
             let points: [CGPoint] = [
@@ -155,7 +155,7 @@ class PathTests: XCTestCase {
                                                     indexedPathLocation2: IndexedPathLocation(componentIndex: 0, elementIndex: 3, t: 0.5))
         XCTAssertEqual(singleComponentPath.selfIntersections(), [expectedIntersection])
     }
-    
+
     func testSelfIntersectsMultiComponentPath() {
         let multiComponentPath = { () -> Path in
             let cgPath = CGMutablePath()
@@ -197,12 +197,12 @@ class PathTests: XCTestCase {
     }
 
     func testPointIsWithinDistanceOfBoundary() {
-        
+
         let circleCGPath = CGMutablePath()
         circleCGPath.addEllipse(in: CGRect(origin: CGPoint(x: -1.0, y: -1.0), size: CGSize(width: 2.0, height: 2.0)))
 
         let circlePath = Path(cgPath: circleCGPath) // a circle centered at origin with radius 1
-        
+
         let d = CGFloat(0.1)
         let p1 = CGPoint(x: -3.0, y: 0.0)
         let p2 = CGPoint(x: -0.9, y: 0.9)
@@ -214,9 +214,9 @@ class PathTests: XCTestCase {
         XCTAssertTrue(circlePath.pointIsWithinDistanceOfBoundary(point: p3, distance: d))  // yes, one of the curves that makes up the circle is within that distance
         XCTAssertTrue(circlePath.pointIsWithinDistanceOfBoundary(point: p3, distance: CGFloat(10.0)))  // yes, so obviously within that distance implementation should early return yes
         XCTAssertFalse(circlePath.pointIsWithinDistanceOfBoundary(point: p4, distance: d)) // no, we are inside the path but too far from the boundary
-        
+
     }
-    
+
     func testEquatable() {
         let rect = CGRect(origin: CGPoint(x: -1, y: -1), size: CGSize(width: 2, height: 2))
         let path1 = Path(cgPath: CGPath(rect: rect, transform: nil))
@@ -225,21 +225,21 @@ class PathTests: XCTestCase {
         XCTAssertNotEqual(path1, path2)
         XCTAssertEqual(path1, path3)
     }
-    
+
     func testIsEqual() {
         let rect = CGRect(origin: CGPoint(x: -1, y: -1), size: CGSize(width: 2, height: 2))
         let path1 = Path(cgPath: CGPath(rect: rect, transform: nil))
         let path2 = Path(cgPath: CGPath(ellipseIn: rect, transform: nil))
         let path3 = Path(cgPath: CGPath(rect: rect, transform: nil))
-        
+
         let string = "hello" as NSString
-        
+
         XCTAssertFalse(path1.isEqual(nil))
         XCTAssertFalse(path1.isEqual(string))
         XCTAssertFalse(path1.isEqual(path2))
         XCTAssertTrue(path1.isEqual(path3))
     }
-    
+
     func testEncodeDecode() {
         let rect = CGRect(origin: CGPoint(x: -1, y: -1), size: CGSize(width: 2, height: 2))
         let path = Path(cgPath: CGPath(rect: rect, transform: nil))
@@ -247,9 +247,9 @@ class PathTests: XCTestCase {
         let decodedPath = NSKeyedUnarchiver.unarchiveObject(with: data) as! Path
         XCTAssertEqual(decodedPath, path)
     }
-    
+
     // MARK: - contains
-    
+
     func testWindingCount() {
         let rect1 = Path(cgPath: CGPath(rect: CGRect(origin: CGPoint(x: -1, y: -1), size: CGSize(width: 2, height: 2)), transform: nil))
         let rect2 = Path(cgPath: CGPath(rect: CGRect(origin: CGPoint(x: -2, y: -2), size: CGSize(width: 4, height: 4)), transform: nil))
@@ -261,7 +261,7 @@ class PathTests: XCTestCase {
         // inside both rects
         XCTAssertEqual(path.windingCount(CGPoint(x: 0, y: 0)), 2)
     }
-    
+
     func testContainsSimple1() {
         let rect = CGRect(origin: CGPoint(x: -1, y: -1), size: CGSize(width: 2, height: 2))
         let path = Path(cgPath: CGPath(rect: rect, transform: nil))
@@ -270,18 +270,18 @@ class PathTests: XCTestCase {
         XCTAssertFalse(path.contains(CGPoint(x: 3, y: 0))) // the third point falls outside the rectangle on the right
         XCTAssertTrue(path.contains(CGPoint(x: -0.99999, y: 0)))  // just *barely* in the rectangle
     }
-    
+
     func testContainsSimple2() {
         let rect = CGRect(origin: CGPoint(x: -1, y: -1), size: CGSize(width: 2, height: 2))
         let path = Path(cgPath: CGPath(ellipseIn: rect, transform: nil))
         XCTAssertFalse(path.contains(CGPoint(x: 5, y: 5)))       // the first point is way outside the circle
         XCTAssertFalse(path.contains(CGPoint(x: -0.8, y: -0.8))) // the second point is outside the circle, but within the bounding rect
         XCTAssertTrue(path.contains(CGPoint(x: 0.3, y: 0.3)))    // the third point falls inside the circle
-        
+
         // the 4th point falls inside the and is a tricky case when using the evenOdd fill mode because it aligns with two path elements exactly at y = 0
         XCTAssertTrue(path.contains(CGPoint(x: 0.5, y: 0.0), using: .evenOdd))
         XCTAssertTrue(path.contains(CGPoint(x: 0.5, y: 0.0), using: .winding))
-        
+
         // the 5th point falls outside the circle, but drawing a horizontal line has a glancing blow with it
         XCTAssertFalse(path.contains(CGPoint(x: 0.1, y: 1.0), using: .evenOdd))
         XCTAssertFalse(path.contains(CGPoint(x: 0.1, y: -1.0), using: .winding))
@@ -290,7 +290,7 @@ class PathTests: XCTestCase {
     func testContainsStar() {
         let starPoints = stride(from: 0.0, to: 2.0 * Double.pi, by: 0.4 * Double.pi).map { CGPoint(x: cos($0), y: sin($0)) }
         let cgPath = CGMutablePath()
-        
+
         cgPath.move(to: starPoints[0])
         cgPath.addLine(to: starPoints[3])
         cgPath.addLine(to: starPoints[1])
@@ -299,12 +299,12 @@ class PathTests: XCTestCase {
         cgPath.closeSubpath()
 
         let path = Path(cgPath: cgPath)
-        
+
         // check a point outside of the star
         let outsidePoint = CGPoint(x: 0.5, y: -0.5)
         XCTAssertFalse(path.contains(outsidePoint, using: .evenOdd))
         XCTAssertFalse(path.contains(outsidePoint, using: .winding))
-        
+
         // using the winding rule, the center of the star is in the path, but with even-odd it's not
         XCTAssertTrue(path.contains(CGPoint.zero, using: .winding))
         XCTAssertFalse(path.contains(CGPoint.zero, using: .evenOdd))
@@ -321,7 +321,7 @@ class PathTests: XCTestCase {
             XCTAssertFalse(path.contains(point, using: .winding), "point \(i)")
         }
     }
-    
+
     func testContainsCircleWithHole() {
         let rect1 = CGRect(origin: CGPoint(x: -3, y: -3), size: CGSize(width: 6, height: 6))
         let circlePath = Path(cgPath: CGPath(ellipseIn: rect1, transform: nil))
@@ -335,7 +335,7 @@ class PathTests: XCTestCase {
         XCTAssertFalse(circleWithHole.contains(CGPoint(x: 4.0, y: 0.0), using: .evenOdd))
         XCTAssertFalse(circleWithHole.contains(CGPoint(x: 4.0, y: 0.0), using: .winding))
     }
-    
+
     func testContainsCornerCase() {
         let cgPath = CGMutablePath()
         let points = [CGPoint(x: 0, y: 0),
@@ -354,7 +354,7 @@ class PathTests: XCTestCase {
         XCTAssertFalse(rotatedSquare.contains(point1))
         XCTAssertFalse(rotatedSquare.contains(point2))
     }
-    
+
     func testContainsRealWorldEdgeCase() {
         // an edge case which caused errors in practice because (rare!) line-curve intersections are found when bounding boxes do not even overlap
         let point = CGPoint(x: 281.2936999253952, y: 221.7262912473492)
@@ -373,7 +373,7 @@ class PathTests: XCTestCase {
         XCTAssertFalse(path.contains(point, using: .evenOdd))
         XCTAssertFalse(path.contains(point, using: .winding))
     }
-    
+
     func testContainsEdgeCaseParallelDerivative() {
         // this is a real-world edge case that can happen with round-rects
         let cgPath = CGMutablePath()
@@ -386,7 +386,7 @@ class PathTests: XCTestCase {
         XCTAssertTrue(path.contains(CGPoint(x: 0.5, y: 0.5)))
         XCTAssertFalse(path.contains(CGPoint(x: 3.0, y: 0.0)))
     }
-    
+
     func testContainsPath() {
         let rect1 = Path(cgPath: CGPath(rect: CGRect(x: 1, y: 1, width: 5, height: 5), transform: nil))
         let rect2 = Path(cgPath: CGPath(rect: CGRect(x: 2, y: 2, width: 3, height: 3), transform: nil)) // fully contained inside rect1
@@ -396,11 +396,11 @@ class PathTests: XCTestCase {
         XCTAssertFalse(rect1.contains(rect3))
         XCTAssertFalse(rect1.contains(rect4))
     }
-    
+
     // TODO: more tests of contains path using .winding rule and where intersections are not crossings
-    
+
     // MARK: - vector boolean operations
-    
+
     private func componentsEqualAsideFromElementOrdering(_ component1: PathComponent, _ component2: PathComponent) -> Bool {
         let curves1 = component1.curves
         let curves2 = component2.curves
@@ -421,7 +421,7 @@ class PathTests: XCTestCase {
         }
         return true
     }
-    
+
     // points on the first square
     let p0 = CGPoint(x: 0.0, y: 0.0)
     let p1 = CGPoint(x: 1.0, y: 0.0) // intersection 1
@@ -429,13 +429,13 @@ class PathTests: XCTestCase {
     let p3 = CGPoint(x: 2.0, y: 1.0) // intersection 2
     let p4 = CGPoint(x: 2.0, y: 2.0)
     let p5 = CGPoint(x: 0.0, y: 2.0)
-    
+
     // points on the second square
     let p6 = CGPoint(x: 1.0, y: -1.0)
     let p7 = CGPoint(x: 3.0, y: -1.0)
     let p8 = CGPoint(x: 3.0, y: 1.0)
     let p9 = CGPoint(x: 1.0, y: 1.0)
-    
+
     private func createSquare1() -> Path {
         return Path(components: [PathComponent(curves:
             [
@@ -446,7 +446,7 @@ class PathTests: XCTestCase {
             ]
         )])
     }
-    
+
     private func createSquare2() -> Path {
         return Path(components: [PathComponent(curves:
         [
@@ -457,7 +457,7 @@ class PathTests: XCTestCase {
         ]
     )])
     }
-    
+
     func testSubtracting() {
         let expectedResult = Path(components: [PathComponent(curves:
             [
@@ -477,7 +477,7 @@ class PathTests: XCTestCase {
             componentsEqualAsideFromElementOrdering(subtracted.components[0], expectedResult.components[0])
         )
     }
-    
+
     func testUnion() {
         let expectedResult = Path(components: [PathComponent(curves:
             [
@@ -499,7 +499,7 @@ class PathTests: XCTestCase {
             componentsEqualAsideFromElementOrdering(unioned.components[0], expectedResult.components[0])
         )
     }
-    
+
     func testIntersecting() {
         let expectedResult = Path(components: [PathComponent(curves:
             [
@@ -517,7 +517,7 @@ class PathTests: XCTestCase {
             componentsEqualAsideFromElementOrdering(intersected.components[0], expectedResult.components[0])
         )
     }
-    
+
     func testSubtractingWindingDirection() {
         // this is a specific test of `subtracting` to ensure that when a component creates a "hole"
         // the order of the hole is reversed so that it is not contained in the shape when using .winding fill rule
@@ -527,14 +527,14 @@ class PathTests: XCTestCase {
         XCTAssertTrue(donut.contains(CGPoint(x: 0.5, y: 0.5), using: .winding))  // inside the donut (but not the hole)
         XCTAssertFalse(donut.contains(CGPoint(x: 1.5, y: 1.5), using: .winding)) // center of donut hole
     }
-    
+
     func testSubtractingEntirelyErased() {
         // this is a specific test of `subtracting` to ensure that if a path component is entirely contained in the subtracting path that it gets removed
         let circle       = Path(cgPath: CGPath(ellipseIn: CGRect(x: -1, y: -1, width: 2, height: 2), transform: nil))
         let biggerCircle = Path(cgPath: CGPath(ellipseIn: CGRect(x: -2, y: -2, width: 4, height: 4), transform: nil))
         XCTAssert(circle.subtract(biggerCircle)!.isEmpty)
     }
-    
+
     func testSubtractingEdgeCase1() {
         // this is a specific edge case test of `subtracting`. There was an issue where if a path element intersected at the exact border between
         // two elements on the other path it would count as two intersections. The winding count would then be incremented twice on the way in
@@ -542,18 +542,18 @@ class PathTests: XCTestCase {
 
         let rectangle = Path(cgPath: CGPath(rect: CGRect(x: -1, y: -1, width: 4, height: 3), transform: nil))
         let circle    = Path(cgPath: CGPath(ellipseIn: CGRect(x: 0, y: 0, width: 4, height: 4), transform: nil))
-        
+
         // the circle intersects the rect at (0,2) and (3, 0.26792) ... the last number being exactly 2 - sqrt(3)
         let difference = rectangle.subtract(circle)!
         XCTAssertEqual(difference.components.count, 1)
         XCTAssertFalse(difference.contains(CGPoint(x: 2.0, y: 2.0)))
     }
-    
+
     func testSubtractingEdgeCase2() {
-        
+
         // this unit test demosntrates an issue that came up in development where the logic for the winding direction
         // when corners intersect was not quite correct.
-        
+
         let square1 = Path(cgPath: CGPath(rect: CGRect(x: 0.0, y: 0.0, width: 2.0, height: 2.0), transform: nil))
         let square2CGPath = CGMutablePath()
         square2CGPath.move(to: CGPoint.zero)
@@ -561,10 +561,10 @@ class PathTests: XCTestCase {
         square2CGPath.addLine(to: CGPoint(x: 2.0, y: 0.0))
         square2CGPath.addLine(to: CGPoint(x: 1.0, y: 1.0))
         square2CGPath.closeSubpath()
-    
+
         let square2 = Path(cgPath: square2CGPath)
         let result = square1.subtract(square2)!
-        
+
         let expectedResultCGPath = CGMutablePath()
         expectedResultCGPath.move(to: CGPoint.zero)
         expectedResultCGPath.addLine(to: CGPoint(x: 1.0, y: 1.0))
@@ -572,13 +572,13 @@ class PathTests: XCTestCase {
         expectedResultCGPath.addLine(to: CGPoint(x: 2.0, y: 2.0))
         expectedResultCGPath.addLine(to: CGPoint(x: 0.0, y: 2.0))
         expectedResultCGPath.closeSubpath()
-        
+
         let expectedResult = Path(cgPath: expectedResultCGPath)
-        
+
         XCTAssertEqual(result.components.count, expectedResult.components.count)
         XCTAssertTrue(componentsEqualAsideFromElementOrdering(result.components[0], expectedResult.components[0]))
     }
-    
+
     func testCrossingsRemoved() {
         let points: [CGPoint] = [
             CGPoint(x: 0, y: 0),
@@ -594,19 +594,19 @@ class PathTests: XCTestCase {
         cgPath.closeSubpath()
         let path = Path(cgPath: cgPath)
         let intersection = CGPoint(x: 1.5, y: 1.5)
-        
+
         let expectedResultCGPath = CGMutablePath()
         expectedResultCGPath.addLines(between: [points[0], points[1], points[2], intersection, points[5]])
         expectedResultCGPath.closeSubpath()
         let expectedResult = Path(cgPath: expectedResultCGPath)
-        
+
         XCTAssertTrue(path.contains(CGPoint(x: 1.5, y: 1.25), using: .winding))
         XCTAssertFalse(path.contains(CGPoint(x: 1.5, y: 1.25), using: .evenOdd))
 
         let result = path.crossingsRemoved()!
         XCTAssertEqual(result.components.count, 1)
         XCTAssertTrue(componentsEqualAsideFromElementOrdering(result.components[0], expectedResult.components[0]))
-        
+
         // check also that the algorithm works when the first point falls *inside* the path
         let cgPathAlt = CGMutablePath()
         cgPathAlt.addLines(between: Array(points[3..<points.count]) + Array(points[1...3]))
@@ -616,7 +616,7 @@ class PathTests: XCTestCase {
         XCTAssertEqual(resultAlt.components.count, 1)
         XCTAssertTrue(componentsEqualAsideFromElementOrdering(resultAlt.components[0], expectedResult.components[0]))
     }
-    
+
     func testCrossingsRemovedNoCrossings() {
         // a test which ensures that if a path has no crossings then crossingsRemoved does not modify it
         let square = Path(cgPath: CGPath(ellipseIn: CGRect(x: 0.0, y: 0.0, width: 1.0, height: 1.0), transform: nil))
@@ -624,14 +624,14 @@ class PathTests: XCTestCase {
         XCTAssertEqual(result.components.count, 1)
         XCTAssertTrue(componentsEqualAsideFromElementOrdering(result.components[0], square.components[0]))
     }
-    
+
     func testCrossingsRemovedEdgeCase() {
         // this is an edge cases which caused difficulty in practice
         // the contour, which intersects at (1,1) creates two squares, one with -1 winding count
         // the other with +1 winding count
         // incorrect implementation of this algorithm previously interpretted
         // the crossing as an entry / exit, which would completely cull off the square with +1 count
-        
+
         let points = [CGPoint(x: 0, y: 1),
                       CGPoint(x: 2, y: 1),
                       CGPoint(x: 2, y: 2),
@@ -652,23 +652,23 @@ class PathTests: XCTestCase {
         XCTAssertEqual(crossingsRemoved.components.count, 1)
         XCTAssertTrue(componentsEqualAsideFromElementOrdering(crossingsRemoved.components[0], contour.components[0]))
     }
-    
+
     func testCrossingsRemovedEdgeCaseInnerLoop() {
-        
+
         // this tests an edge case of crossingsRemoved() when vertices of the path are exactly equal
         // the path does a complete loop in the middle
-        
+
         let cgPath = CGMutablePath()
-        
+
         cgPath.move(to: CGPoint.zero)
         cgPath.addLine(to: CGPoint(x: 2.0, y: 0.0))
-        
+
         // loop in a complete circle back to 2, 0
         cgPath.addArc(tangent1End: CGPoint(x: 3.0, y: 0.0), tangent2End: CGPoint(x: 3.0, y: 1.0), radius: 1)
         cgPath.addArc(tangent1End: CGPoint(x: 3.0, y: 2.0), tangent2End: CGPoint(x: 2.0, y: 2.0), radius: 1)
         cgPath.addArc(tangent1End: CGPoint(x: 1.0, y: 2.0), tangent2End: CGPoint(x: 1.0, y: 1.0), radius: 1)
         cgPath.addArc(tangent1End: CGPoint(x: 1.0, y: 0.0), tangent2End: CGPoint(x: 2.0, y: 0.0), radius: 1)
-        
+
         // proceed around to close the shape (grazing the loop at (2,2)
         cgPath.addLine(to: CGPoint(x: 4.0, y: 0.0))
         cgPath.addLine(to: CGPoint(x: 4.0, y: 2.0))
@@ -677,7 +677,7 @@ class PathTests: XCTestCase {
         cgPath.closeSubpath()
 
         let path = Path(cgPath: cgPath)
-        
+
         // Quartz 'addArc' function creates some terrible near-zero length line segments
         // let's eliminate those
         let curves2 = path.components[0].curves.map {
@@ -687,7 +687,7 @@ class PathTests: XCTestCase {
             })!
         }.filter { $0.length() > 0.0 }
         let cleanPath = Path(components: [PathComponent(curves: curves2)])
-        
+
         let result = cleanPath.crossingsRemoved(accuracy: 1.0e-4)!
 
         // check that the inner loop was eliminated by checking the winding count in the middle
@@ -695,19 +695,19 @@ class PathTests: XCTestCase {
         XCTAssertEqual(result.windingCount(CGPoint(x: 2.0, y: 1)), 1) // if the inner loop wasn't eliminated we'd have a winding count of 2 here
         XCTAssertEqual(result.windingCount(CGPoint(x: 3.5, y: 1)), 1)
     }
-    
+
     func testCrossingsRemovedRealWorldEdgeCaseMagicNumbers() {
         // in practice this data was failing because 'smallNumber', a magic number in augmented graph was too large
         // it was fixed by decreasing the value by 10x
         let cgPath = CGMutablePath()
         let start = CGPoint(x: 79.59559290956605, y: 697.9008011912572)
         cgPath.move(to: start)
-        cgPath.addCurve(to: CGPoint(x:71.31576744881897, y:729.0705310397749), control1: CGPoint(x:85.91646553575535, y:708.7944954952286), control2: CGPoint(x:82.2094612873204, y:722.7496586836662))
-        cgPath.addCurve(to: CGPoint(x:40.14603795970622, y:720.7907053704894), control1: CGPoint(x:60.4220735042526, y:735.3914034574259), control2: CGPoint(x:46.46691031581487, y:731.6843992089908))
-        cgPath.addCurve(to: CGPoint(x:37.21144227099133, y:706.7177736592248), control1: CGPoint(x:39.07549105339858, y:718.7074812854011), control2: CGPoint(x:37.21110624960683, y:711.947464952338))
-        cgPath.addCurve(to: CGPoint(x:62.477966856736, y:686.6750666235641), control1: CGPoint(x:38.65395965539626, y:694.2059748336982), control2: CGPoint(x:49.96616803120935, y:685.2325492391592))
-        cgPath.addCurve(to: CGPoint(x:82.52067606376023, y:711.9415914596509), control1: CGPoint(x:74.98976785362623, y:688.1175842583111), control2: CGPoint(x:83.96319344816517, y:699.4297926341243))
-        cgPath.addCurve(to: start, control1: CGPoint(x:82.51999960076027, y:706.7206820370851), control2: CGPoint(x:80.65889482357387, y:699.9715389099819))
+        cgPath.addCurve(to: CGPoint(x: 71.31576744881897, y: 729.0705310397749), control1: CGPoint(x: 85.91646553575535, y: 708.7944954952286), control2: CGPoint(x: 82.2094612873204, y: 722.7496586836662))
+        cgPath.addCurve(to: CGPoint(x: 40.14603795970622, y: 720.7907053704894), control1: CGPoint(x: 60.4220735042526, y: 735.3914034574259), control2: CGPoint(x: 46.46691031581487, y: 731.6843992089908))
+        cgPath.addCurve(to: CGPoint(x: 37.21144227099133, y: 706.7177736592248), control1: CGPoint(x: 39.07549105339858, y: 718.7074812854011), control2: CGPoint(x: 37.21110624960683, y: 711.947464952338))
+        cgPath.addCurve(to: CGPoint(x: 62.477966856736, y: 686.6750666235641), control1: CGPoint(x: 38.65395965539626, y: 694.2059748336982), control2: CGPoint(x: 49.96616803120935, y: 685.2325492391592))
+        cgPath.addCurve(to: CGPoint(x: 82.52067606376023, y: 711.9415914596509), control1: CGPoint(x: 74.98976785362623, y: 688.1175842583111), control2: CGPoint(x: 83.96319344816517, y: 699.4297926341243))
+        cgPath.addCurve(to: start, control1: CGPoint(x: 82.51999960076027, y: 706.7206820370851), control2: CGPoint(x: 80.65889482357387, y: 699.9715389099819))
         let path = Path(cgPath: cgPath)
         let result = path.crossingsRemoved(accuracy: 0.01)
          // in practice .crossingsRemoved was cutting off most of the shape
@@ -718,21 +718,21 @@ class PathTests: XCTestCase {
             XCTAssertEqual(result.components[0].elementCount, 5) // with crossings removed we should have 1 fewer curve (the last one)
         }
     }
-    
+
     func testCrossingsRemovedAnotherRealWorldCase() {
-        
+
         // TODO: re-enable this unit test -- I was never able to get this to pass
         // (must be re-enabled in Mac and iOS test suite separately)
-        
+
         let cgPath = CGMutablePath()
         let start = CGPoint(x: 503.3060153966664, y: 766.9140612367046)
         cgPath.move(to: start)
-        cgPath.addCurve(to: CGPoint(x:517.9306651149989, y:762.0523534483476), control1: CGPoint(x:506.0019772976378, y:761.5330522602719), control2: CGPoint(x:512.5496560294043, y:759.3563914926846))
-        cgPath.addCurve(to: CGPoint(x:522.7923732205169, y:776.6770033255823), control1: CGPoint(x:523.3116744085926, y:764.7483155082213), control2: CGPoint(x:525.4883351761798, y:771.2959942399877))
-        cgPath.addCurve(to: CGPoint(x:520.758836935199, y:764.316674774872), control1: CGPoint(x:522.6619398993569, y:776.9550303733141), control2: CGPoint(x:522.7228057838222, y:776.8532852161298))
-        cgPath.addCurve(to: CGPoint(x:520.6170414159213, y:779.7723863761416), control1: CGPoint(x:524.9876580913353, y:768.6238074338997), control2: CGPoint(x:524.9241740749491, y:775.5435652200052))
-        cgPath.addCurve(to: CGPoint(x:505.16132944417086, y:779.6305912206088), control1: CGPoint(x:516.3099083864128, y:784.001207896023), control2: CGPoint(x:509.3901506003072, y:783.9377238796366))
-        cgPath.addCurve(to: start, control1: CGPoint(x:503.19076843492786, y:767.0872665416827), control2: CGPoint(x:503.3761460381431, y:766.7563954079359))
+        cgPath.addCurve(to: CGPoint(x: 517.9306651149989, y: 762.0523534483476), control1: CGPoint(x: 506.0019772976378, y: 761.5330522602719), control2: CGPoint(x: 512.5496560294043, y: 759.3563914926846))
+        cgPath.addCurve(to: CGPoint(x: 522.7923732205169, y: 776.6770033255823), control1: CGPoint(x: 523.3116744085926, y: 764.7483155082213), control2: CGPoint(x: 525.4883351761798, y: 771.2959942399877))
+        cgPath.addCurve(to: CGPoint(x: 520.758836935199, y: 764.316674774872), control1: CGPoint(x: 522.6619398993569, y: 776.9550303733141), control2: CGPoint(x: 522.7228057838222, y: 776.8532852161298))
+        cgPath.addCurve(to: CGPoint(x: 520.6170414159213, y: 779.7723863761416), control1: CGPoint(x: 524.9876580913353, y: 768.6238074338997), control2: CGPoint(x: 524.9241740749491, y: 775.5435652200052))
+        cgPath.addCurve(to: CGPoint(x: 505.16132944417086, y: 779.6305912206088), control1: CGPoint(x: 516.3099083864128, y: 784.001207896023), control2: CGPoint(x: 509.3901506003072, y: 783.9377238796366))
+        cgPath.addCurve(to: start, control1: CGPoint(x: 503.19076843492786, y: 767.0872665416827), control2: CGPoint(x: 503.3761460381431, y: 766.7563954079359))
         let path = Path(cgPath: cgPath)
         let result = path.crossingsRemoved(accuracy: 0.01)
         // in practice .crossingsRemoved was cutting off most of the shape
@@ -766,9 +766,9 @@ class PathTests: XCTestCase {
                         control2: CGPoint(x: 130.4334714935808, y: 49.19162153453483))
 
         let p = Path(cgPath: cgPath)
-        let _ = p.crossingsRemoved(accuracy: 0.0001)
+        _ = p.crossingsRemoved(accuracy: 0.0001)
     }
-    
+
     func testCrossingsRemovedMulticomponent() {
         // this path is a square with a self-intersecting inner region that should form a square shaped hole when crossings
         // this is similar to what happens if you use CoreGraphics to stroke shape, albeit simplified here for the sake of testing
@@ -788,7 +788,7 @@ class PathTests: XCTestCase {
         cgPath.closeSubpath()
         let path = Path(cgPath: cgPath)
         let result = path.crossingsRemoved()!
-        
+
         let expectedResult = Path(cgPath: { () -> CGPath in
             let cgPath = CGMutablePath()
             cgPath.addRect(CGRect(x: 0, y: 0, width: 5, height: 5))
@@ -801,16 +801,16 @@ class PathTests: XCTestCase {
             cgPath.closeSubpath()
             return cgPath
         }())
-        
+
         XCTAssertEqual(result.components.count, 2)
         XCTAssertTrue(componentsEqualAsideFromElementOrdering(result.components[0], expectedResult.components[0]))
         XCTAssertTrue(componentsEqualAsideFromElementOrdering(result.components[1], expectedResult.components[1]))
     }
-    
+
     func testCrossingsRemovedRealWorldInfiniteLoop() {
-        
+
         // in testing this data previously caused an infinite loop in AgumentedGraph.booleanOperation(_:)
-        
+
         let cgPath = CGMutablePath()
         cgPath.move(to: CGPoint(x: 431.2394694928875, y: 109.81690300533613))
         cgPath.addCurve(to: CGPoint(x: 430.66935231730844, y: 110.3870201809152), control1: CGPoint(x: 431.2394694928875, y: 110.13177002702506), control2: CGPoint(x: 430.9842193389974, y: 110.3870201809152))
@@ -837,12 +837,12 @@ class PathTests: XCTestCase {
         cgPath.closeSubpath()
 
         let path = Path(cgPath: cgPath)
-        let _ = path.crossingsRemoved(accuracy: 0.01)
-        
+        _ = path.crossingsRemoved(accuracy: 0.01)
+
         // for now the test's only expectation is that we do not go into an infinite loop
         // TODO: make test stricter
     }
-    
+
     func testOffset() {
         let circle = Path(cgPath: CGPath(ellipseIn: CGRect(x: 0, y: 0, width: 2, height: 2), transform: nil)) // ellipse with radius 1 centered at 1,1
         let offsetCircle = circle.offset(distance: -1) // should be roughly an ellipse with radius 2
@@ -865,7 +865,7 @@ class PathTests: XCTestCase {
             }
         }
     }
-    
+
     func testDisjointcomponentsNesting() {
         XCTAssertEqual(Path().disjointComponents(), [])
         // test that a simple square just gives the same square back
@@ -905,9 +905,9 @@ class PathTests: XCTestCase {
         XCTAssert(result4.contains(squareWithHolePath))
         XCTAssert(result4.contains(pegWithHolePath))
     }
-    
+
     func testSubtractionPerformance() {
-        
+
         func circlePath(origin: CGPoint, radius: CGFloat, numPoints: Int) -> Path {
             let c: CGFloat = 0.551915024494 * radius * 4.0 / CGFloat(numPoints)
             let cgPath = CGMutablePath()
@@ -927,13 +927,13 @@ class PathTests: XCTestCase {
             }
             return Path(cgPath: cgPath)
         }
-        
+
         let numPoints = 300
         let path1 = circlePath(origin: CGPoint(x: 0, y: 0), radius: 100, numPoints: numPoints)
         let path2 = circlePath(origin: CGPoint(x: 1, y: 0), radius: 100, numPoints: numPoints)
 
         self.measure { // roughly 0.018s in debug mode
-            let _ = path1.subtract(path2, accuracy: 1.0e-3)
+            _ = path1.subtract(path2, accuracy: 1.0e-3)
         }
     }
 

--- a/BezierKit/BezierKitTests/PathTests.swift
+++ b/BezierKit/BezierKitTests/PathTests.swift
@@ -762,10 +762,10 @@ class PathTests: XCTestCase {
         // Quartz 'addArc' function creates some terrible near-zero length line segments
         // let's eliminate those
         let curves2 = path.components[0].curves.map {
-            return BezierKit.createCurve(from: $0.points.map { point in
+            return type(of: $0).init(points: $0.points.map { point in
                 let rounded = CGPoint(x: round(point.x), y: round(point.y))
                 return distance(point, rounded) < 1.0e-3 ? rounded : point
-            })!
+            })
         }.filter { $0.length() > 0.0 }
         let cleanPath = Path(components: [PathComponent(curves: curves2)])
 

--- a/BezierKit/BezierKitTests/QuadraticBezierCurveTests.swift
+++ b/BezierKit/BezierKitTests/QuadraticBezierCurveTests.swift
@@ -17,12 +17,12 @@ class QuadraticBezierCurveTests: XCTestCase {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
+
 //    func testInitializerArray() {
 //    }
 //
@@ -41,7 +41,7 @@ class QuadraticBezierCurveTests: XCTestCase {
         let q3 = QuadraticBezierCurve(start: CGPoint(x: 1.0, y: 1.0), end: CGPoint(x: 5.0, y: 1.0), mid: CGPoint(x: 5.0, y: 1.0), t: 1.0)
         XCTAssertEqual(q3, QuadraticBezierCurve(p0: CGPoint(x: 1.0, y: 1.0), p1: CGPoint(x: 5.0, y: 1.0), p2: CGPoint(x: 5.0, y: 1.0)))
     }
-    
+
     func testBasicProperties() {
         let q = QuadraticBezierCurve(p0: CGPoint(x: 1.0, y: 1.0), p1: CGPoint(x: 3.5, y: 2.0), p2: CGPoint(x: 6.0, y: 1.0))
         XCTAssert(q.simple)
@@ -49,7 +49,7 @@ class QuadraticBezierCurveTests: XCTestCase {
         XCTAssertEqual(q.startingPoint, CGPoint(x: 1.0, y: 1.0))
         XCTAssertEqual(q.endingPoint, CGPoint(x: 6.0, y: 1.0))
     }
-    
+
     func testSetStartEndPoints() {
         var q = QuadraticBezierCurve(p0: CGPoint(x: 5.0, y: 6.0), p1: CGPoint(x: 6.0, y: 5.0), p2: CGPoint(x: 8.0, y: 7.0))
         q.startingPoint = CGPoint(x: 4.0, y: 5.0)
@@ -78,7 +78,7 @@ class QuadraticBezierCurveTests: XCTestCase {
         let expectedBoundingBox1 = BoundingBox(p1: CGPoint(x: 1.0, y: 1.0),
                                                p2: CGPoint(x: 5.0, y: 2.0))
         XCTAssertEqual(q1.boundingBox, expectedBoundingBox1)
-       
+
         // hits codepath where midpoint pushes down x coordinate of bounding box
         let q2 = QuadraticBezierCurve(p0: CGPoint(x: 1.0, y: 1.0), p1: CGPoint(x: -1.0, y: 2.0), p2: CGPoint(x: 1.0, y: 3.0))
         let expectedBoundingBox2 = BoundingBox(p1: CGPoint(x: 0.0, y: 1.0),
@@ -94,7 +94,7 @@ class QuadraticBezierCurveTests: XCTestCase {
 //
 //    func testCompute() {
 //    }
-    
+
 // -- MARK: - methods for which default implementations provided by protocol
 
 //    func testLength() {
@@ -162,7 +162,7 @@ class QuadraticBezierCurveTests: XCTestCase {
         XCTAssertTrue( distance(q2.compute(i[0].t2), expectedResult1) < epsilon)
         XCTAssertTrue( distance(q2.compute(i[1].t2), expectedResult2) < epsilon)
     }
-    
+
     func testIntersectionsQuadraticMaxIntersections() {
         let epsilon: CGFloat = 1.0e-5
         let q1: QuadraticBezierCurve = QuadraticBezierCurve(start: CGPoint(x: 0.0, y: 0.0),
@@ -186,7 +186,7 @@ class QuadraticBezierCurveTests: XCTestCase {
     }
 
     // MARK: -
-    
+
     func testEquatable() {
         let p0 = CGPoint(x: 1.0, y: 2.0)
         let p1 = CGPoint(x: 2.0, y: 3.0)

--- a/BezierKit/BezierKitTests/ShapeTests.swift
+++ b/BezierKit/BezierKitTests/ShapeTests.swift
@@ -10,9 +10,9 @@ import XCTest
 @testable import BezierKit
 
 class ShapeTests: XCTestCase {
-    
-    let testQuadCurve = QuadraticBezierCurve(p0: CGPoint(x: 0.0, y: 0.0), p1: CGPoint(x: 1.0, y: 1.0), p2: CGPoint(x: 1.0, y:  2.0))
-    
+
+    let testQuadCurve = QuadraticBezierCurve(p0: CGPoint(x: 0.0, y: 0.0), p1: CGPoint(x: 1.0, y: 1.0), p2: CGPoint(x: 1.0, y: 2.0))
+
     func testShapeIntersection() {
         let c1 = LineSegment(p0: CGPoint(x: 0.0, y: 1.0), p1: CGPoint(x: 1.0, y: 0.0))
         let c2 = LineSegment(p0: CGPoint(x: 0.0, y: 1.0), p1: CGPoint(x: 1.0, y: 2.0))
@@ -27,7 +27,7 @@ class ShapeTests: XCTestCase {
         si3 = ShapeIntersection(curve1: c1, curve2: c2, intersections: [])
         XCTAssertNotEqual(si1, si3) // intersections don't match
     }
-    
+
     func testInitializer() {
         let forward = testQuadCurve.offset(distance: 2)[0]
         let back = testQuadCurve.offset(distance: -2)[0]
@@ -39,7 +39,7 @@ class ShapeTests: XCTestCase {
         XCTAssert(s.endcap.virtual == false)
         XCTAssert(s.endcap.curve == LineSegment(p0: forward.endingPoint, p1: back.startingPoint))
     }
-    
+
     func testBoundingBox() {
         let forward = testQuadCurve.offset(distance: 2)[0]
         let back = testQuadCurve.offset(distance: -2)[0]
@@ -53,7 +53,7 @@ class ShapeTests: XCTestCase {
         let forward1 = line1.offset(distance: sqrt(2))[0]
         let back1 = line1.offset(distance: -sqrt(2))[0].reversed()
         let s1 = Shape(forward1, back1, true, true)
-        
+
         let line2 = LineSegment(p0: CGPoint(x: 1.0, y: 10.0), p1: CGPoint(x: 1.0, y: -10.0))
         let forward2 = line2.offset(distance: 0.5)[0]
         let back2 = line2.offset(distance: -0.5)[0].reversed()
@@ -61,7 +61,7 @@ class ShapeTests: XCTestCase {
 
         let shapeIntersections = s1.intersects(shape: s2, accuracy: 1.0e-4)
         XCTAssertEqual(shapeIntersections.count, 2)
-        
+
         // check the first shape intersection
         XCTAssert(shapeIntersections[0].curve1 == s1.back)
         XCTAssert(shapeIntersections[0].curve2 == s2.forward)
@@ -77,7 +77,7 @@ class ShapeTests: XCTestCase {
         p1 = shapeIntersections[1].curve1.compute(shapeIntersections[1].intersections[0].t1)
         p2 = shapeIntersections[1].curve2.compute(shapeIntersections[1].intersections[0].t2)
         XCTAssert(distance(p1, p2) < epsilon)
-        
+
         // test a non-intersecting case where bounding boxes overlap
         let s3 = LineSegment(p0: CGPoint(x: -3, y: -3), p1: CGPoint(x: 3, y: 3)).outlineShapes(distance: 1)
         XCTAssertEqual(s1.intersects(shape: s3[0]), [])
@@ -85,7 +85,7 @@ class ShapeTests: XCTestCase {
         let s4 = LineSegment(p0: CGPoint(x: -6, y: -6), p1: CGPoint(x: -4, y: -4)).outlineShapes(distance: sqrt(2))
         XCTAssertEqual(s1.intersects(shape: s4[0]), [])
     }
-    
+
     func testEquatable() {
         let a = CGPoint(x: -1, y: 1)
         let b = CGPoint(x: 1, y: 1)

--- a/BezierKit/BezierKitTests/TransformableTests.swift
+++ b/BezierKit/BezierKitTests/TransformableTests.swift
@@ -13,7 +13,7 @@ class TransformableTests: XCTestCase {
 
     // rotates by 90 degrees ccw and then shifts (-1, 1)
     let transform = CGAffineTransform(a: 0, b: 1, c: -1, d: 0, tx: -1, ty: 1)
-    
+
     override func setUp() {
         // assert(CGPoint(x: 1, y: 0).applying(transform) == CGPoint(x: -1, y: 2))
     }
@@ -26,7 +26,7 @@ class TransformableTests: XCTestCase {
         let l = LineSegment(p0: CGPoint(x: -1, y: -1), p1: CGPoint(x: 3, y: 1))
         XCTAssertEqual(l.copy(using: transform), LineSegment(p0: CGPoint(x: 0, y: 0), p1: CGPoint(x: -2, y: 4)))
     }
-    
+
     func testTransformQuadraticCurve() {
         let q = QuadraticBezierCurve(p0: CGPoint(x: -1, y: -1),
                                      p1: CGPoint(x: 3, y: 1),
@@ -35,7 +35,7 @@ class TransformableTests: XCTestCase {
                                                                       p1: CGPoint(x: -2, y: 4),
                                                                       p2: CGPoint(x: 0, y: 8)))
     }
-    
+
     func testTransformCubicCurve() {
         let c = CubicBezierCurve(p0: CGPoint(x: -1, y: -1),
                                  p1: CGPoint(x: 3, y: 1),
@@ -46,18 +46,18 @@ class TransformableTests: XCTestCase {
                                                                   p2: CGPoint(x: 0, y: 8),
                                                                   p3: CGPoint(x: -1, y: 9)))
     }
-    
+
     func testTransformPath() {
-        
+
         // just a simple path with two path components made up of line segments
-        
+
         let l1 = LineSegment(p0: CGPoint(x: -1, y: -1), p1: CGPoint(x: 3, y: 1))
         let l2 = LineSegment(p0: CGPoint(x: 1, y: 1), p1: CGPoint(x: 2, y: 3))
 
         let path = Path(components: [PathComponent(curves: [l1]), PathComponent(curves: [l2])])
-        
+
         let transformedPath = path.copy(using: transform)
-        
+
         let expectedl1 = LineSegment(p0: CGPoint(x: 0, y: 0), p1: CGPoint(x: -2, y: 4))
         let expectedl2 = LineSegment(p0: CGPoint(x: -2, y: 2), p1: CGPoint(x: -4, y: 3))
 

--- a/BezierKit/BezierKit_MacTests/BezierKit_MacTests.swift
+++ b/BezierKit/BezierKit_MacTests/BezierKit_MacTests.swift
@@ -12,7 +12,7 @@ import BezierKit
 class BezierKit_MacTests: XCTestCase {
 
 //    you can put Mac specific tests here (empty for now)
-    
+
 //    override func setUp() {
 //        super.setUp()
 //        // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -22,5 +22,5 @@ class BezierKit_MacTests: XCTestCase {
 //        // Put teardown code here. This method is called after the invocation of each test method in the class.
 //        super.tearDown()
 //    }
-    
+
 }

--- a/BezierKit/BezierKit_iOSTests/BezierKit_iOSTests.swift
+++ b/BezierKit/BezierKit_iOSTests/BezierKit_iOSTests.swift
@@ -10,9 +10,9 @@ import XCTest
 import BezierKit
 
 class BezierKit_iOSTests: XCTestCase {
-    
+
 //    you can put iOS specific test here (empty for now)
-    
+
 //    override func setUp() {
 //        super.setUp()
 //        // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -22,5 +22,5 @@ class BezierKit_iOSTests: XCTestCase {
 //        // Put teardown code here. This method is called after the invocation of each test method in the class.
 //        super.tearDown()
 //    }
-    
+
 }

--- a/BezierKit/Library/ArcApproximateable.swift
+++ b/BezierKit/Library/ArcApproximateable.swift
@@ -39,13 +39,13 @@ public protocol ArcApproximateable: BezierCurve {
 extension ArcApproximateable {
     public func arcs(errorThreshold: CGFloat = 0.5) -> [Arc] {
         func iterate(errorThreshold: CGFloat, circles: [Arc]) -> [Arc] {
-            
+
             var result: [Arc] = circles
             var s: CGFloat = 0.0
             var e: CGFloat = 1.0
             var safety: Int = 0
             // we do a binary search to find the "good `t` closest to no-longer-good"
-            
+
             let error = {(pc: CGPoint, np1: CGPoint, s: CGFloat, e: CGFloat) -> CGFloat in
                 let q = (e - s) / 4.0
                 let c1 = self.compute(s + q)
@@ -55,46 +55,46 @@ extension ArcApproximateable {
                 let d2  = Utils.dist(pc, c2)
                 return abs(d1-ref) + abs(d2-ref)
             }
-            
+
             repeat {
                 safety=0
-                
+
                 // step 1: start with the maximum possible arc
                 e = 1.0
-                
+
                 // points:
                 let np1 = self.compute(s)
-                var prev_arc: Arc? = nil
-                var arc: Arc? = nil
-                
+                var prev_arc: Arc?
+                var arc: Arc?
+
                 // booleans:
                 var curr_good = false
                 var prev_good = false
                 var done = false
-                
+
                 // numbers:
                 var m = e
                 var prev_e: CGFloat = 1.0
-                
+
                 // step 2: find the best possible arc
                 repeat {
                     prev_good = curr_good
                     prev_arc = arc
                     m = (s + e)/2.0
-                    
+
                     let np2 = self.compute(m)
                     let np3 = self.compute(e)
-                    
+
                     arc = Utils.getccenter(np1, np2, np3, Interval(start: s, end: e))
-                    
+
                     let errorAmount = error(arc!.origin, np1, s, e)
                     curr_good = errorAmount <= errorThreshold
-                    
+
                     done = prev_good && !curr_good
                     if !done {
                         prev_e = e
                     }
-                    
+
                     // this arc is fine: we can move 'e' up to see if we can find a wider arc
                     if curr_good {
                         // if e is already at max, then we're done for this arc.
@@ -104,25 +104,24 @@ extension ArcApproximateable {
                             break
                         }
                         // if not, move it up by half the iteration distance
-                        e = e + (e-s)/2.0
-                    }
-                    else {
+                        e += (e-s)/2.0
+                    } else {
                         // this is a bad arc: we need to move 'e' down to find a good arc
                         e = m
                     }
                     safety += 1
                 } while !done && safety <= 100
-                
+
 //                if safety >= 100 {
 //                    NSLog("arc abstraction somehow failed...")
 //                    break
 //                }
-            
+
                 prev_arc = prev_arc != nil ? prev_arc : arc
                 result.append(prev_arc!)
                 s = prev_e
             } while e < 1.0
-            
+
             return result
         }
         let circles: [Arc] = []

--- a/BezierKit/Library/ArcApproximateable.swift
+++ b/BezierKit/Library/ArcApproximateable.swift
@@ -117,7 +117,7 @@ extension ArcApproximateable {
 //                    break
 //                }
 
-                prev_arc = prev_arc != nil ? prev_arc : arc
+                prev_arc = prev_arc ?? arc
                 result.append(prev_arc!)
                 s = prev_e
             } while e < 1.0

--- a/BezierKit/Library/AugmentedGraph.swift
+++ b/BezierKit/Library/AugmentedGraph.swift
@@ -179,10 +179,7 @@ internal class PathLinkedListRepresentation {
                 let n = prev.normal(0.5)
                 #warning("you need to add an API for this one!")
                 let intersections = path.intersections(with: Path(curve: LineSegment(p0: p, p1: p + n)))
-                var s: CGFloat = 0.5
-                if let i = intersections.first(where: { $0.indexedPathLocation2.t != 0 }) {
-                    s = 0.5 * i.indexedPathLocation2.t
-                }
+                let s: CGFloat = 0.5 * (intersections.map({$0.indexedPathLocation2.t}).first(where: {$0 > 0}) ?? 1.0)
                 initialWinding = path.windingCount(p + s * n)
             } else {
                 initialWinding = path.windingCount(lists[i][0].emitPrevious().compute(0.5))

--- a/BezierKit/Library/AugmentedGraph.swift
+++ b/BezierKit/Library/AugmentedGraph.swift
@@ -178,7 +178,8 @@ internal class PathLinkedListRepresentation {
                 let p = prev.compute(0.5)
                 let n = prev.normal(0.5)
                 #warning("you need to add an API for this one!")
-                let intersections = path.intersections(with: Path(curve: LineSegment(p0: p, p1: p + n)))
+                let line = LineSegment(p0: p, p1: p + n)
+                let intersections = path.intersections(with: Path(curve: line))
                 let s: CGFloat = 0.5 * (intersections.map({$0.indexedPathLocation2.t}).first(where: {$0 > 0}) ?? 1.0)
                 initialWinding = path.windingCount(p + s * n)
             } else {

--- a/BezierKit/Library/AugmentedGraph.swift
+++ b/BezierKit/Library/AugmentedGraph.swift
@@ -200,10 +200,11 @@ internal class PathLinkedListRepresentation {
                 let previous = v.emitPrevious()
                 let next = v.emitNext()
 
-                let n1 = neighbor.emitPrevious().normal(0)
-                let n2 = neighbor.emitNext().normal(0)
-                let v1 = previous.normal(0)
-                let v2 = next.normal(0)
+                let smallNumber: CGFloat = 0.001
+                let n1 = neighbor.emitPrevious().compute(smallNumber) - v.location
+                let n2 = neighbor.emitNext().compute(smallNumber) - v.location
+                let v1 = previous.compute(smallNumber) - v.location
+                let v2 = next.compute(smallNumber) - v.location
 
                 let windingCountChange = windingCountAdjustment(v1, v2, n1, n2)
 

--- a/BezierKit/Library/AugmentedGraph.swift
+++ b/BezierKit/Library/AugmentedGraph.swift
@@ -72,8 +72,8 @@ internal class PathLinkedListRepresentation {
         assert(start !== end)
         assert(v.isIntersection)
         v.splitInfo = Vertex.SplitInfo(t: t)
-        let t0: CGFloat = (start.splitInfo != nil) ? start.splitInfo!.t : 0.0
-        let t1: CGFloat = (end.splitInfo != nil) ? end.splitInfo!.t : 1.0
+        let t0: CGFloat = start.splitInfo?.t ?? 0.0
+        let t1: CGFloat = end.splitInfo?.t ?? 1.0
         // locate the element for the vertex transitions
         /*
          TODO: this code assumes t0 < t < t1, which could definitely be false if there are multiple intersections against the same element at the same point
@@ -212,9 +212,16 @@ internal class PathLinkedListRepresentation {
                     v.intersectionInfo.isEntry = wasInside == false && isInside == true
                     v.intersectionInfo.isExit = wasInside == true && isInside == false
                 }
+
+                let altCount = path.windingCount(next.compute(0.5))
+                print("winding count = \(windingCount) vs \(altCount)")
+
             }
+
+            print("done")
+
             if initialWinding != windingCount {
-                print("warning: winding count found in .crossingsRemoved() not consistent")
+                print("warning: winding count found in .markEntryExit() not consistent")
             }
         }
     }

--- a/BezierKit/Library/AugmentedGraph.swift
+++ b/BezierKit/Library/AugmentedGraph.swift
@@ -17,20 +17,18 @@ internal func between(_ v: CGPoint, _ a: CGPoint, _ b: CGPoint) -> Bool {
     let signedAngleAV = signedAngle(a, v)
     if signedAngleAB > 0 {
         return signedAngleAV > 0 && signedAngleAV < signedAngleAB
-    }
-    else if signedAngleAB < 0 {
+    } else if signedAngleAB < 0 {
         return signedAngleAV < 0 && signedAngleAV > signedAngleAB
-    }
-    else {
+    } else {
         return signedAngleAV == 0
     }
 }
 
 internal class PathLinkedListRepresentation {
-    
+
     private var lists: [[Vertex]] = []
     private let path: Path
-    
+
     private func insertIntersectionVertex(_ v: Vertex, replacingVertexAtStartOfElementIndex elementIndex: Int, inList list: inout [Vertex]) {
         assert(v.isIntersection)
         let r = list[elementIndex]
@@ -45,7 +43,7 @@ internal class PathLinkedListRepresentation {
         // replace the list pointer with v
         list[elementIndex] = v
     }
-    
+
     private func insertIntersectionVertex(_ v: Vertex, between start: Vertex, and end: Vertex, at t: CGFloat, for element: BezierCurve, inList list: inout [Vertex]) {
         assert(start !== end)
         assert(v.isIntersection)
@@ -65,20 +63,19 @@ internal class PathLinkedListRepresentation {
         start.setNextVertex(v, transition: VertexTransition(curve: element1))
         end.setPreviousVertex(v)
     }
-    
+
     internal func insertIntersectionVertex(_ v: Vertex, at location: IndexedPathLocation) {
-        
+
         assert(v.isIntersection)
-        
+
         var list = self.lists[location.componentIndex]
-        
+
         assert(location.t != 0, "intersects are assumed pre-processed to have a t=1 intersection at the previous path element instead!")
-        
+
         if location.t == 1 {
             // this vertex needs to replace the end vertex of the element
             insertIntersectionVertex(v, replacingVertexAtStartOfElementIndex: Utils.mod(location.elementIndex+1, list.count), inList: &list)
-        }
-        else {
+        } else {
             var start = list[location.elementIndex]
             while (start.next.splitInfo != nil) && start.next.splitInfo!.t < location.t {
                 start = start.next
@@ -92,7 +89,7 @@ internal class PathLinkedListRepresentation {
         }
         self.lists[location.componentIndex] = list
     }
-    
+
     private func createListFor(component: PathComponent) -> [Vertex] {
         guard component.elementCount > 0 else {
             return []
@@ -124,12 +121,12 @@ internal class PathLinkedListRepresentation {
         // return list of vertexes that point to the start of each element
         return elements
     }
-    
+
     init(_ p: Path) {
         self.path = p
         self.lists = p.components.map { self.createListFor(component: $0) }
     }
-    
+
     fileprivate func nonCrossingComponents() -> [PathComponent] {
         // returns the components of this path that do not cross the path passed as the argument to markEntryExit(_:)
         var result: [PathComponent] = []
@@ -146,7 +143,7 @@ internal class PathLinkedListRepresentation {
         }
         return result
     }
-    
+
     fileprivate func markEntryExit(_ path: Path, useRelativeWinding: Bool = false) {
         let fillRule: PathFillRule = useRelativeWinding ? .winding : .evenOdd
 
@@ -159,22 +156,22 @@ internal class PathLinkedListRepresentation {
                 }
                 let previous = v.emitPrevious()
                 let next = v.emitNext()
-                
+
                 // we used to use the derivative here but in important cases derivatives can be exactly tangent
                 // at intersections!
                 let smallNumber: CGFloat = 0.001
-                
+
                 let n1 = neighbor.emitPrevious().compute(smallNumber) - v.location
                 let n2 = neighbor.emitNext().compute(smallNumber) - v.location
-                
+
                 let v1 = previous.compute(smallNumber) - v.location
                 let v2 = next.compute(smallNumber) - v.location
-                
+
                 let side1 = between(v1, n1, n2)
                 let side2 = between(v2, n1, n2)
-                
+
                 let cross = (side1 != side2)
-                
+
                 if cross {
                     // TODO: there's an issue when corners intersect (try AugmentedGraphTests.testCornersIntersect which has this problem, even though it passes)
                     // the relative winding count can be decremented both for entry and for exit. This is not an issue with the even-odd winding rule, but using
@@ -182,14 +179,13 @@ internal class PathLinkedListRepresentation {
                     let c = v2.cross(n2)
                     if c < 0 {
                         relativeWindingCount += 1
-                    }
-                    else if c > 0 {
+                    } else if c > 0 {
                         relativeWindingCount -= 1
                     }
                 }
                 v.intersectionInfo.nextWinding = relativeWindingCount
             }
-            
+
             // determine the initial winding count (winding count before first vertex)
             var initialWinding = 0
             if useRelativeWinding {
@@ -203,27 +199,26 @@ internal class PathLinkedListRepresentation {
                     }
                 }
                 initialWinding = -minimumWinding
-                
+
                 let prev = lists[i][0].emitPrevious()
                 let a = prev.compute(0.5)
                 // TODO: 1.0e-5 is a magic number (just an arbitrary small value)
                 let b = a + 1.0e-5 * prev.normal(0.5)
                 //let c = a - 1.0e-5 * prev.normal(0.5)
-                
+
                 let w1 = path.windingCount(b)
                 //let w2 = path.windingCount(c)
-                
+
                 // print("w1 = \(w1)")
                 // print("w2 = \(w2)")
-                
+
                 if w1 == initialWinding-1 {
                     initialWinding = w1
                 }
-            }
-            else {
+            } else {
                 initialWinding = path.windingCount(lists[i][0].emitPrevious().compute(0.5))
             }
-            
+
             // adjust winding counts based on the initial winding count
             self.forEachVertexInComponent(atIndex: i) { v in
                 guard v.isIntersection else {
@@ -231,7 +226,7 @@ internal class PathLinkedListRepresentation {
                 }
                 v.intersectionInfo.nextWinding += initialWinding
             }
-            
+
             // for each intersection, determine isEntry / isExit based on winding count
             var windingCount: Int = initialWinding
             self.forEachVertexInComponent(atIndex: i) { v in
@@ -261,15 +256,15 @@ internal class PathLinkedListRepresentation {
             current = next
         } while current !== v
     }
-    
+
     private func forEachVertexInComponent(atIndex index: Int, _ callback: (Vertex) -> Void) {
         self.forEachVertexStartingFrom(lists[index].first!, callback)
     }
-    
+
     internal func startingVertex(forComponentIndex componentIndex: Int, elementIndex: Int) -> Vertex {
         return self.lists[componentIndex][elementIndex]
     }
-    
+
     func forEachVertex(_ callback: (Vertex) -> Void) {
         lists.forEach {
             self.forEachVertexStartingFrom($0.first!, callback)
@@ -285,7 +280,7 @@ internal enum BooleanPathOperation {
 }
 
 internal class AugmentedGraph {
-    
+
     func connectNeighbors(_ vertex1: Vertex, _ vertex2: Vertex) {
         vertex1.intersectionInfo.neighbor = vertex2
         vertex2.intersectionInfo.neighbor = vertex1
@@ -293,20 +288,20 @@ internal class AugmentedGraph {
         vertex1.location = location
         vertex2.location = location
     }
-    
+
     internal var list1: PathLinkedListRepresentation
     internal var list2: PathLinkedListRepresentation
-    
+
     private let path1: Path
     private let path2: Path
-    
+
     internal init(path1: Path, path2: Path, intersections: [PathIntersection]) {
-        
+
         func intersectionVertexForPath(_ path: Path, at l: IndexedPathLocation) -> Vertex {
             let v = Vertex(location: path.point(at: l), isIntersection: true)
             return v
         }
-        
+
         self.path1 = path1
         self.path2 = path2
         self.list1 = PathLinkedListRepresentation(path1)
@@ -325,7 +320,7 @@ internal class AugmentedGraph {
             list2.markEntryExit(path1, useRelativeWinding: useRelativeWinding)
         }
     }
-    
+
     private func shouldMoveForwards(fromVertex v: Vertex, forOperation operation: BooleanPathOperation, isOnFirstCurve: Bool) -> Bool {
         switch operation {
         case .removeCrossings:
@@ -338,13 +333,13 @@ internal class AugmentedGraph {
             return v.intersectionInfo.isEntry
         }
     }
-    
+
     internal func booleanOperation(_ operation: BooleanPathOperation) -> Path? {
-        
+
         // special cases for components which do not cross
         let nonCrossingComponents1: [PathComponent] = self.list1.nonCrossingComponents()
         let nonCrossingComponents2: [PathComponent] = self.list2.nonCrossingComponents()
-        
+
         func anyPointOnComponent(_ c: PathComponent) -> CGPoint {
             return c.startingPoint
         }
@@ -362,7 +357,7 @@ internal class AugmentedGraph {
             pathComponents += nonCrossingComponents1.filter { path2.contains(anyPointOnComponent($0)) == true }
             pathComponents += nonCrossingComponents2.filter { path1.contains(anyPointOnComponent($0)) == true }
         }
-        
+
         // handle components that have crossings (the main algorithm)
         var unvisitedCrossings: [Vertex] = []
         list1.forEachVertex {
@@ -386,11 +381,11 @@ internal class AugmentedGraph {
                     curves.append(movingForwards ? v.emitNext() : v.emitPrevious())
                     v = movingForwards ? v.next : v.previous
                 } while v.isCrossing == false
-                
+
                 unvisitedCrossings = unvisitedCrossings.filter { $0 !== v }
                 v = v.intersectionInfo.neighbor!
                 isOnFirstCurve = !isOnFirstCurve
-                
+
                 if isOnFirstCurve && unvisitedCrossings.contains(v) == false && v !== start {
                     return nil
                 }
@@ -430,45 +425,45 @@ internal class Vertex {
     public var location: CGPoint
     public let isIntersection: Bool
     // pointers must be set after initialization
-    
+
     public struct IntersectionInfo {
         public var isEntry: Bool = false
         public var isExit: Bool = false
         public var nextWinding: Int = 0
-        public weak var neighbor: Vertex? = nil
+        public weak var neighbor: Vertex?
     }
     public var intersectionInfo: IntersectionInfo = IntersectionInfo()
-    
+
     public var isCrossing: Bool {
         guard let neighborInfo = self.intersectionInfo.neighbor?.intersectionInfo else {
             return false
         }
         return self.isIntersection && (self.intersectionInfo.isEntry || self.intersectionInfo.isExit) && (neighborInfo.isEntry || neighborInfo.isExit)
     }
-    
+
     internal struct SplitInfo {
         var t: CGFloat
     }
-    internal var splitInfo: SplitInfo? = nil // non-nil only when vertex is inserted by splitting an element
-    
+    internal var splitInfo: SplitInfo? // non-nil only when vertex is inserted by splitting an element
+
     public private(set) var next: Vertex! = nil
     public private(set) weak var previous: Vertex! = nil
     public private(set) var nextTransition: VertexTransition! = nil
-    
+
     public func setNextVertex(_ vertex: Vertex, transition: VertexTransition) {
         self.next = vertex
         self.nextTransition = transition
     }
-    
+
     public func setPreviousVertex(_ vertex: Vertex) {
         self.previous = vertex
     }
-    
+
     init(location: CGPoint, isIntersection: Bool) {
         self.location = location
         self.isIntersection = isIntersection
     }
-    
+
     internal func emitTo(_ end: CGPoint, using transition: VertexTransition) -> BezierCurve {
         switch transition {
         case .line:
@@ -479,11 +474,11 @@ internal class Vertex {
             return CubicBezierCurve(p0: self.location, p1: c1, p2: c2, p3: end)
         }
     }
-    
+
     public func emitNext() -> BezierCurve {
         return self.emitTo(next.location, using: nextTransition)
     }
-    
+
     public func emitPrevious() -> BezierCurve {
         return self.previous.emitNext().reversed()
     }

--- a/BezierKit/Library/AugmentedGraph.swift
+++ b/BezierKit/Library/AugmentedGraph.swift
@@ -115,9 +115,6 @@ internal class PathLinkedListRepresentation {
     }
 
     private func createListFor(component: PathComponent) -> [Vertex] {
-        guard component.elementCount > 0 else {
-            return []
-        }
         assert(component.startingPoint == component.endingPoint, "this method assumes component is closed!")
         var elements: [Vertex] = [] // elements[i] is the first vertex of curves[i]
         let firstPoint: CGPoint = component.startingPoint

--- a/BezierKit/Library/AugmentedGraph.swift
+++ b/BezierKit/Library/AugmentedGraph.swift
@@ -182,7 +182,6 @@ internal class PathLinkedListRepresentation {
                 let prev = startingVertex.emitPrevious()
                 let p = prev.compute(0.5)
                 let n = prev.normal(0.5)
-                #warning("you need to add an API for this one!")
                 let line = LineSegment(p0: p, p1: p + n)
                 let intersections = path.intersections(with: Path(curve: line))
                 let s: CGFloat = 0.5 * (intersections.map({$0.indexedPathLocation2.t}).first(where: {$0 > 0}) ?? 1.0)

--- a/BezierKit/Library/BezierCurve+Intersection.swift
+++ b/BezierKit/Library/BezierCurve+Intersection.swift
@@ -57,18 +57,33 @@ internal func helperIntersectsCurveLine<U>(_ curve: U, _ line: LineSegment, reve
     let lineDirection = (line.p1 - line.p0)
     let lineLength = lineDirection.lengthSquared
     let intersections = Utils.roots(points: curve.points, line: line).compactMap({t -> Intersection? in
-        let p = curve.compute(t) - line.p0
+
+        var t1 = CGFloat(t)
+        let smallValue: CGFloat = 1.0e-8
+        assert(smallValue < CGFloat(Utils.epsilon))
+
+        guard t1 >= -smallValue, t1 <= 1.0+smallValue else {
+            return nil
+        }
+
+        let p = curve.compute(t1) - line.p0
         var t2 = p.dot(lineDirection) / lineLength
+        guard t2 >= -smallValue, t2 <= 1.0+smallValue else {
+            return nil
+        }
+        if Utils.approximately(Double(t1), 0.0, precision: Utils.epsilon) {
+            t1 = 0.0
+        }
+        if Utils.approximately(Double(t1), 1.0, precision: Utils.epsilon) {
+            t1 = 1.0
+        }
         if Utils.approximately(Double(t2), 0.0, precision: Utils.epsilon) {
             t2 = 0.0
         }
         if Utils.approximately(Double(t2), 1.0, precision: Utils.epsilon) {
             t2 = 1.0
         }
-        guard t2 >= 0.0, t2 <= 1.0 else {
-            return nil
-        }
-        return reversed ? Intersection(t1: t2, t2: t) : Intersection(t1: t, t2: t2)
+        return reversed ? Intersection(t1: t2, t2: t1) : Intersection(t1: t1, t2: t2)
     })
     return sortedAndUniquifiedIntersections(intersections)
 }

--- a/BezierKit/Library/BezierCurve+Intersection.swift
+++ b/BezierKit/Library/BezierCurve+Intersection.swift
@@ -37,7 +37,7 @@ public extension BezierCurve {
 
 private func sortedAndUniquifiedIntersections(_ intersections: [Intersection]) -> [Intersection] {
     let sortedIntersections = intersections.sorted(by: <)
-    return sortedIntersections.reduce([Intersection]()) { (intersection: [Intersection], next : Intersection) in
+    return sortedIntersections.reduce([Intersection]()) { (intersection: [Intersection], next: Intersection) in
         return (intersection.isEmpty || (intersection.last!) != next) ? intersection + [next] : intersection
     }
 }
@@ -136,14 +136,11 @@ public extension LineSegment {
         }
         if self.p0 == line.p0 {
             return [Intersection(t1: 0.0, t2: 0.0)]
-        }
-        else if self.p0 == line.p1 {
+        } else if self.p0 == line.p1 {
             return [Intersection(t1: 0.0, t2: 1.0)]
-        }
-        else if self.p1 == line.p0 {
+        } else if self.p1 == line.p0 {
             return [Intersection(t1: 1.0, t2: 0.0)]
-        }
-        else if self.p1 == line.p1 {
+        } else if self.p1 == line.p1 {
             return [Intersection(t1: 1.0, t2: 1.0)]
         }
 
@@ -187,7 +184,7 @@ public extension LineSegment {
             t2 = 1.0
         }
 
-        if t1 > 1.0 || t1 < 0.0  {
+        if t1 > 1.0 || t1 < 0.0 {
             return [] // t1 out of interval [0, 1]
         }
         if t2 > 1.0 || t2 < 0.0 {

--- a/BezierKit/Library/BezierCurve+Intersection.swift
+++ b/BezierKit/Library/BezierCurve+Intersection.swift
@@ -146,6 +146,9 @@ public extension LineSegment {
     }
     func intersections(with line: LineSegment) -> [Intersection] {
 
+        guard self.p1 != self.p0, line.p1 != line.p0 else {
+            return []
+        }
         guard self.boundingBox.overlaps(line.boundingBox) else {
             return []
         }

--- a/BezierKit/Library/BezierCurve.swift
+++ b/BezierKit/Library/BezierCurve.swift
@@ -30,17 +30,17 @@ public struct Subcurve<CurveType> where CurveType: BezierCurve {
         self.t2 = 1.0
         self.curve = curve
     }
-    
+
     internal init(t1: CGFloat, t2: CGFloat, curve: CurveType) {
         self.t1 = t1
         self.t2 = t2
         self.curve = curve
     }
-    
+
     internal func split(from t1: CGFloat, to t2: CGFloat) -> Subcurve<CurveType> {
         let curve: CurveType = self.curve.split(from: t1, to: t2)
-        return Subcurve<CurveType>(t1: Utils.map(t1, 0,1, self.t1, self.t2),
-                                   t2: Utils.map(t2, 0,1, self.t1, self.t2),
+        return Subcurve<CurveType>(t1: Utils.map(t1, 0, 1, self.t1, self.t2),
+                                   t2: Utils.map(t2, 0, 1, self.t1, self.t2),
                                    curve: curve)
     }
 
@@ -48,7 +48,7 @@ public struct Subcurve<CurveType> where CurveType: BezierCurve {
         let (left, right) = curve.split(at: t)
         let t1 = self.t1
         let t2 = self.t2
-        let tSplit = Utils.map(t, 0,1, t1, t2)
+        let tSplit = Utils.map(t, 0, 1, t1, t2)
         let subcurveLeft = Subcurve<CurveType>(t1: t1, t2: tSplit, curve: left)
         let subcurveRight = Subcurve<CurveType>(t1: tSplit, t2: t2, curve: right)
         return (left: subcurveLeft, right: subcurveRight)
@@ -62,9 +62,9 @@ extension Subcurve: Equatable where CurveType: Equatable {
 // MARK: -
 
 extension BezierCurve {
-    
+
     // MARK: -
-    
+
     private var dpoints: [[CGPoint]] {
         var ret: [[CGPoint]] = []
         var p: [CGPoint] = self.points
@@ -73,7 +73,7 @@ extension BezierCurve {
             let c = d-1
             var list: [CGPoint] = []
             list.reserveCapacity(c)
-            for j:Int in 0..<c {
+            for j: Int in 0..<c {
                 let dpt: CGPoint = CGFloat(c) * (p[j+1] - p[j])
                 list.append(dpt)
             }
@@ -82,11 +82,11 @@ extension BezierCurve {
         }
         return ret
     }
-    
+
     private var linear: Bool {
         let order = self.order
         let points = self.points
-        var a = Utils.align(points, p1:points[0], p2:points[order])
+        var a = Utils.align(points, p1: points[0], p2: points[order])
         for i in 0..<a.count {
             // TODO: investigate horrible magic number usage
             if abs(a[i].y) > 0.0001 {
@@ -95,16 +95,16 @@ extension BezierCurve {
         }
         return true
     }
-        
+
     /*
      Calculates the length of this Bezier curve. Length is calculated using numerical approximation, specifically the Legendre-Gauss quadrature algorithm.
      */
     public func length() -> CGFloat {
         return Utils.length({(_ t: CGFloat) in self.derivative(t)})
     }
-    
-    // MARK:
-    
+
+    // MARK: 
+
     // computes the extrema for each dimension
     internal func internalExtrema(includeInflection: Bool) -> [[CGFloat]] {
         var xyz: [[CGFloat]] = []
@@ -121,10 +121,10 @@ extension BezierCurve {
         }
         return xyz
     }
-    
+
     public func extrema() -> (xyz: [[CGFloat]], values: [CGFloat] ) {
         let xyz = self.internalExtrema(includeInflection: true)
-        var roots = xyz.flatMap{$0}.sorted() // the roots for each dimension, flattened and sorted
+        var roots = xyz.flatMap {$0}.sorted() // the roots for each dimension, flattened and sorted
         var values: [CGFloat] = []
         if !roots.isEmpty {
             values.reserveCapacity(roots.count)
@@ -139,12 +139,12 @@ extension BezierCurve {
         }
         return (xyz: xyz, values: values)
     }
-    
+
     // MARK: -
     public func hull(_ t: CGFloat) -> [CGPoint] {
         return Utils.hull(self.points, t)
     }
-        
+
     public func generateLookupTable(withSteps steps: Int = 100) -> [CGPoint] {
         assert(steps >= 0)
         var table: [CGPoint] = []
@@ -156,7 +156,7 @@ extension BezierCurve {
         return table
     }
     // MARK: -
-    
+
     /*
      Reduces a curve to a collection of "simple" subcurves, where a simpleness is defined as having all control points on the same side of the baseline (cubics having the additional constraint that the control-to-end-point lines may not cross), and an angle between the end point normals no greater than 60 degrees.
      
@@ -166,7 +166,7 @@ extension BezierCurve {
      */
 
     public func reduce() -> [Subcurve<Self>] {
-        
+
         let step: CGFloat = BezierKit.reduceStepSize
         var extrema: [CGFloat] = []
         self.extrema().values.forEach {
@@ -182,7 +182,7 @@ extension BezierCurve {
         // aritifically add 0.0 and 1.0 to our extreme points
         extrema.insert(0.0, at: 0)
         extrema.append(1.0)
-        
+
         // first pass: split on extrema
         var pass1: [Subcurve<Self>] = []
         pass1.reserveCapacity(extrema.count-1)
@@ -192,7 +192,7 @@ extension BezierCurve {
             let curve = self.split(from: t1, to: t2)
             pass1.append(Subcurve(t1: t1, t2: t2, curve: curve))
         }
-        
+
         func bisectionMethod(min: CGFloat, max: CGFloat, tolerance: CGFloat, callback: (_ value: CGFloat) -> Bool) -> CGFloat {
             var lb = min // lower bound (callback(x <= lb) should return true
             var ub = max // upper bound (callback(x >= ub) should return false
@@ -200,14 +200,13 @@ extension BezierCurve {
                 let val = 0.5 * (lb + ub)
                 if callback(val) {
                     lb = val
-                }
-                else {
+                } else {
                     ub = val
                 }
             }
             return lb
         }
-        
+
         // second pass: further reduce these segments to simple segments
         var pass2: [Subcurve<Self>] = []
         pass2.reserveCapacity(pass1.count)
@@ -220,8 +219,7 @@ extension BezierCurve {
                     // if the step is small or the full segment is simple, use it
                     pass2.append(fullSegment)
                     t1 = 1.0
-                }
-                else {
+                } else {
                     // otherwise use bisection method to find a suitable step size
                     let t2 = bisectionMethod(min: t1 + adjustedStep, max: 1.0, tolerance: adjustedStep) {
                         return p1.split(from: t1, to: $0).curve.simple
@@ -234,25 +232,25 @@ extension BezierCurve {
         })
         return pass2
     }
-    
+
     // MARK: -
-    
+
     /*
      Scales a curve with respect to the intersection between the end point normals. Note that this will only work if that point exists, which is only guaranteed for simple segments.
      */
     public func scale(distance d: CGFloat) -> Self {
         return internalScale(scaler: .constant(d))
     }
-    
+
     private func scale(distanceFunction distanceFn: @escaping DistanceFunction) -> Self {
         return internalScale(scaler: .function(distanceFn))
     }
-    
+
     private func internalScale(scaler: ScaleEnum) -> Self {
-        
+
         let order = self.order
         guard self.order > 0 else { return self } // undefined behavior for points
-        
+
         let r1: CGFloat
         let r2: CGFloat
         switch scaler {
@@ -263,25 +261,25 @@ extension BezierCurve {
             r1 = distanceFunction(0)
             r2 = distanceFunction(1)
         }
-        
+
         var v = [ self.internalOffset(t: 0, distance: 10), self.internalOffset(t: 1, distance: 10) ]
         // move all points by distance 'd' wrt the origin 'o'
         var points: [CGPoint] = self.points
         var np: [CGPoint] = [CGPoint](repeating: .zero, count: self.order + 1)
-        
+
         // move end points by fixed distance along normal.
         np[0]       = points[0]     + r1 * v[0].n
         np[order]   = points[order] + r2 * v[1].n
-        
+
         guard self.order > 1 else { return Self.init(points: np) } // for line segments nothing left to do
-        
+
         let o = Utils.linesIntersection(v[0].p, v[0].c, v[1].p, v[1].c)
-        
+
         switch scaler {
-        case .constant(_):
+        case .constant:
             // move control points to lie on the intersection of the offset
             // derivative vector, and the origin-through-control vector
-            for t in [0,1] {
+            for t in [0, 1] {
                 if (self.order==2) && (t != 0) {
                     break
                 }
@@ -298,7 +296,7 @@ extension BezierCurve {
                 let angle = Utils.angle(o: points[0], v1: points[self.order], v2: points[1])
                 return angle > 0
             }()
-            for t in [0,1] {
+            for t in [0, 1] {
                 if (self.order==2) && (t != 0) {
                     break
                 }
@@ -313,9 +311,9 @@ extension BezierCurve {
         }
         return Self.init(points: np)
     }
-    
+
     // MARK: -
-    
+
     public func offset(distance d: CGFloat) -> [BezierCurve] {
         if self.linear {
             let n = self.normal(0)
@@ -330,17 +328,17 @@ extension BezierCurve {
             return $0.curve.scale(distance: d)
         })
     }
-    
+
     public func offset(t: CGFloat, distance d: CGFloat) -> CGPoint {
         return self.internalOffset(t: t, distance: d).p
     }
-    
+
     private func internalOffset(t: CGFloat, distance d: CGFloat) -> (c: CGPoint, n: CGPoint, p: CGPoint) {
         let c = self.compute(t)
         let n = self.normal(t)
         return (c: c, n: n, p: c + d * n)
     }
-    
+
     // MARK: - intersection
 
     public func project(_ point: CGPoint) -> (point: CGPoint, t: CGFloat) {
@@ -348,54 +346,53 @@ extension BezierCurve {
     }
 
     // MARK: - outlines
-    
+
     public func outline(distance d1: CGFloat) -> PathComponent {
         return internalOutline(d1: d1, d2: d1, d3: 0.0, d4: 0.0, graduated: false)
     }
-    
+
     public func outline(distanceAlongNormal d1: CGFloat, distanceOppositeNormal d2: CGFloat) -> PathComponent {
         return internalOutline(d1: d1, d2: d2, d3: 0.0, d4: 0.0, graduated: false)
     }
-    
+
     public func outline(distanceAlongNormalStart d1: CGFloat,
                         distanceOppositeNormalStart d2: CGFloat,
                         distanceAlongNormalEnd d3: CGFloat,
                         distanceOppositeNormalEnd d4: CGFloat) -> PathComponent {
         return internalOutline(d1: d1, d2: d2, d3: d3, d4: d4, graduated: true)
     }
-    
+
     private func internalOutline(d1: CGFloat, d2: CGFloat, d3: CGFloat, d4: CGFloat, graduated: Bool) -> PathComponent {
-        
+
         let reduced = self.reduce()
         let len = reduced.count
         var fcurves: [BezierCurve] = []
         var bcurves: [BezierCurve] = []
         //        var p
         let tlen = self.length()
-        
-        let linearDistanceFunction = {(_ s: CGFloat,_ e: CGFloat,_ tlen: CGFloat,_ alen: CGFloat,_ slen: CGFloat) -> DistanceFunction in
+
+        let linearDistanceFunction = {(_ s: CGFloat, _ e: CGFloat, _ tlen: CGFloat, _ alen: CGFloat, _ slen: CGFloat) -> DistanceFunction in
             return { (_ v: CGFloat) -> CGFloat in
                 let f1: CGFloat = alen / tlen
                 let f2: CGFloat = (alen+slen) / tlen
                 let d: CGFloat = e-s
-                return Utils.map(v, 0,1, s+f1*d, s+f2*d)
+                return Utils.map(v, 0, 1, s+f1*d, s+f2*d)
             }
         }
-        
+
         // form curve oulines
         var alen: CGFloat = 0.0
-        
+
         for segment in reduced {
             let slen = segment.curve.length()
             if graduated {
-                fcurves.append(segment.curve.scale(distanceFunction: linearDistanceFunction( d1,  d3, tlen, alen, slen)  ))
+                fcurves.append(segment.curve.scale(distanceFunction: linearDistanceFunction( d1, d3, tlen, alen, slen)  ))
                 bcurves.append(segment.curve.scale(distanceFunction: linearDistanceFunction(-d2, -d4, tlen, alen, slen)  ))
-            }
-            else {
+            } else {
                 fcurves.append(segment.curve.scale(distance: d1))
                 bcurves.append(segment.curve.scale(distance: -d2))
             }
-            alen = alen + slen
+            alen += slen
         }
 
         func cleanupCurves(_ curves: inout [BezierCurve]) {
@@ -427,17 +424,17 @@ extension BezierCurve {
         let le = LineSegment(p0: fe, p1: be)
         let segments = [ls] + fcurves + [le] + bcurves
         //        let slen = segments.count
-        
+
         return PathComponent(curves: segments)
-        
+
     }
-    
+
     // MARK: shapes
-    
+
     public func outlineShapes(distance d1: CGFloat, accuracy: CGFloat = BezierKit.defaultIntersectionAccuracy) -> [Shape] {
         return self.outlineShapes(distanceAlongNormal: d1, distanceOppositeNormal: d1, accuracy: accuracy)
     }
-    
+
     public func outlineShapes(distanceAlongNormal d1: CGFloat, distanceOppositeNormal d2: CGFloat, accuracy: CGFloat = BezierKit.defaultIntersectionAccuracy) -> [Shape] {
         let outline = self.outline(distanceAlongNormal: d1, distanceOppositeNormal: d2)
         var shapes: [Shape] = []

--- a/BezierKit/Library/BezierCurve.swift
+++ b/BezierKit/Library/BezierCurve.swift
@@ -124,7 +124,7 @@ extension BezierCurve {
 
     public func extrema() -> (xyz: [[CGFloat]], values: [CGFloat] ) {
         let xyz = self.internalExtrema(includeInflection: true)
-        var roots = xyz.flatMap {$0}.sorted() // the roots for each dimension, flattened and sorted
+        var roots = xyz.joined().sorted() // the roots for each dimension, flattened and sorted
         var values: [CGFloat] = []
         if !roots.isEmpty {
             values.reserveCapacity(roots.count)

--- a/BezierKit/Library/BezierCurve.swift
+++ b/BezierKit/Library/BezierCurve.swift
@@ -450,21 +450,6 @@ extension BezierCurve {
 public let defaultIntersectionAccuracy = CGFloat(0.5)
 internal let reduceStepSize: CGFloat = 0.01
 
-// MARK: factory
-
-internal func createCurve(from points: [CGPoint]) -> BezierCurve? {
-    switch points.count {
-    case 2:
-        return LineSegment(points: points)
-    case 3:
-        return QuadraticBezierCurve(points: points)
-    case 4:
-        return CubicBezierCurve(points: points)
-    default:
-        return nil
-    }
-}
-
 public func == (left: BezierCurve, right: BezierCurve) -> Bool {
     return left.points == right.points
 }

--- a/BezierKit/Library/BoundingVolumeHierarchy.swift
+++ b/BezierKit/Library/BoundingVolumeHierarchy.swift
@@ -17,11 +17,11 @@ private func right(_ index: Int) -> Int {
 }
 
 final internal class BVH {
-    
+
     private let boundingBoxes: UnsafePointer<BoundingBox>
     private let lastRowIndex: Int
     private let elementCount: Int
-    
+
     internal static func leafNodeIndexToElementIndex(_ nodeIndex: Int, elementCount: Int, lastRowIndex: Int) -> Int {
         assert(isLeaf(nodeIndex, elementCount: elementCount))
         var elementIndex = nodeIndex - lastRowIndex
@@ -39,15 +39,15 @@ final internal class BVH {
         }
         return nodeIndex
     }
-    
+
     private static func isLeaf(_ index: Int, elementCount: Int) -> Bool {
         return index >= elementCount-1
     }
-    
+
     var boundingBox: BoundingBox {
         return self.boundingBoxes[0]
     }
-    
+
     init(boxes elementBoxes: [BoundingBox]) {
         assert(!elementBoxes.isEmpty)
         self.elementCount = elementBoxes.count
@@ -70,11 +70,11 @@ final internal class BVH {
         }
         self.boundingBoxes = UnsafePointer<BoundingBox>(boxes)
     }
-    
+
     deinit {
         self.boundingBoxes.deallocate()
     }
-    
+
     func visit(callback: (BVHNode, Int) -> Bool) {
         let elementCount = self.elementCount
         let lastRowIdnex = self.lastRowIndex
@@ -102,7 +102,7 @@ final internal class BVH {
     func enumerateSelfIntersections(callback: (Int, Int) -> Void) {
         self.enumerateIntersections(with: self, callback: callback)
     }
-    
+
     func enumerateIntersections(with other: BVH, callback: (Int, Int) -> Void) {
         let elementCount1 = self.elementCount
         let elementCount2 = other.elementCount
@@ -114,8 +114,7 @@ final internal class BVH {
             if BVH.isLeaf(index, elementCount: elementCount1) { // if it's a leaf node
                 let elementIndex = BVH.leafNodeIndexToElementIndex(index, elementCount: elementCount1, lastRowIndex: lastRowIndex1)
                 callback(elementIndex, elementIndex)
-            }
-            else {
+            } else {
                 let l = left(index)
                 let r = right(index)
                 intersects(index: l, callback: callback)
@@ -133,26 +132,22 @@ final internal class BVH {
                 let elementIndex1 = BVH.leafNodeIndexToElementIndex(index1, elementCount: elementCount1, lastRowIndex: lastRowIndex1)
                 let elementIndex2 = BVH.leafNodeIndexToElementIndex(index2, elementCount: elementCount2, lastRowIndex: lastRowIndex2)
                 callback(elementIndex1, elementIndex2)
-            }
-            else if leaf1 {
+            } else if leaf1 {
                 intersects(index1: index1, index2: left(index2), callback: callback)
                 intersects(index1: index1, index2: right(index2), callback: callback)
-            }
-            else if leaf2 {
+            } else if leaf2 {
                 intersects(index1: left(index1), index2: index2, callback: callback)
                 intersects(index1: right(index1), index2: index2, callback: callback)
-            }
-            else {
+            } else {
                 intersects(index1: left(index1), index2: left(index2), callback: callback)
                 intersects(index1: left(index1), index2: right(index2), callback: callback)
                 intersects(index1: right(index1), index2: left(index2), callback: callback)
                 intersects(index1: right(index1), index2: right(index2), callback: callback)
             }
         }
-        if (other === self) {
+        if other === self {
             intersects(index: 0, callback: callback)
-        }
-        else {
+        } else {
             intersects(index1: 0, index2: 0, callback: callback)
         }
     }

--- a/BezierKit/Library/CGPoint+Overloads.swift
+++ b/BezierKit/Library/CGPoint+Overloads.swift
@@ -8,6 +8,8 @@
 
 import CoreGraphics
 
+// swiftlint:disable shorthand_operator
+
 public extension CGPoint {
     var length: CGFloat {
         return sqrt(self.lengthSquared)
@@ -43,7 +45,7 @@ private let badSubscriptError = "bad subscript (out of bounds)"
 
 public extension CGPoint {
     static internal let infinity: CGPoint = CGPoint(x: CGFloat.infinity, y: CGFloat.infinity)
-    
+
     static internal var dimensions: Int {
         return 2
     }
@@ -58,8 +60,7 @@ public extension CGPoint {
             assert(index == 0 || index == 1)
             if index == 0 {
                 return self.x
-            }
-            else {
+            } else {
                 return self.y
             }
         }
@@ -67,8 +68,7 @@ public extension CGPoint {
             assert(index == 0 || index == 1)
             if index == 0 {
                 self.x = newValue
-            }
-            else {
+            } else {
                 self.y = newValue
             }
         }

--- a/BezierKit/Library/CubicBezierCurve.swift
+++ b/BezierKit/Library/CubicBezierCurve.swift
@@ -14,11 +14,11 @@ import CoreGraphics
 public struct CubicBezierCurve: NonlinearBezierCurve, ArcApproximateable, Equatable {
 
     public var p0, p1, p2, p3: CGPoint
-    
+
     public var points: [CGPoint] {
         return [p0, p1, p2, p3]
     }
-    
+
     public var order: Int {
         return 3
     }
@@ -31,7 +31,7 @@ public struct CubicBezierCurve: NonlinearBezierCurve, ArcApproximateable, Equata
             p0 = newValue
         }
     }
-    
+
     public var endingPoint: CGPoint {
         get {
             return p3
@@ -40,9 +40,9 @@ public struct CubicBezierCurve: NonlinearBezierCurve, ArcApproximateable, Equata
             p3 = newValue
         }
     }
-    
+
     // MARK: - Initializers
-    
+
     public init(points: [CGPoint]) {
         precondition(points.count == 4)
         self.p0 = points[0]
@@ -50,20 +50,20 @@ public struct CubicBezierCurve: NonlinearBezierCurve, ArcApproximateable, Equata
         self.p2 = points[2]
         self.p3 = points[3]
     }
-    
+
     public init(p0: CGPoint, p1: CGPoint, p2: CGPoint, p3: CGPoint) {
         self.p0 = p0
         self.p1 = p1
         self.p2 = p2
         self.p3 = p3
     }
-    
+
     public init(lineSegment l: LineSegment) {
         let oneThird: CGFloat = 1.0 / 3.0
         let twoThirds: CGFloat = 2.0 / 3.0
         self.init(p0: l.p0, p1: twoThirds * l.p0 + oneThird * l.p1, p2: oneThird * l.p0 + twoThirds * l.p1, p3: l.p1)
     }
-    
+
     public init(quadratic q: QuadraticBezierCurve) {
         let oneThird: CGFloat = 1.0 / 3.0
         let twoThirds: CGFloat = 2.0 / 3.0
@@ -83,17 +83,17 @@ public struct CubicBezierCurve: NonlinearBezierCurve, ArcApproximateable, Equata
 - parameter d: optional strut length with the full strut being length d * (1-t)/t. If omitted or `nil` the distance from `mid` to the baseline (line from `start` to `end`) is used.
 */
     public init(start: CGPoint, end: CGPoint, mid: CGPoint, t: CGFloat = 0.5, d: CGFloat? = nil) {
-        
+
         let s = start
         let b = mid
         let e = end
         let oneMinusT = 1.0 - t
 
         let abc = Utils.getABC(n: 3, S: s, B: b, E: e, t: t)
-        
+
         let d1 = d ?? Utils.dist(b, abc.C)
         let d2 = d1 * oneMinusT / t
-        
+
         let selen = Utils.dist(start, end)
         let l = (1.0 / selen) * (e - s)
         let b1 = d1 * l
@@ -108,11 +108,11 @@ public struct CubicBezierCurve: NonlinearBezierCurve, ArcApproximateable, Equata
         let nc1 = s + (v1 - s) / t
         let nc2 = e + (v2 - e) / oneMinusT
         // ...done
-        self.init(p0:s, p1: nc1, p2: nc2, p3: e)
+        self.init(p0: s, p1: nc1, p2: nc2, p3: e)
     }
-    
+
     // MARK: -
-    
+
     public var simple: Bool {
         guard p0 != p1 || p1 != p2 || p2 != p3 else { return true }
         let a1 = Utils.angle(o: self.p0, v1: self.p3, v2: self.p1)
@@ -157,7 +157,7 @@ public struct CubicBezierCurve: NonlinearBezierCurve, ArcApproximateable, Equata
         let temp3 = c*p2
         return temp1 + temp2 + temp3
     }
-    
+
     public func split(from t1: CGFloat, to t2: CGFloat) -> CubicBezierCurve {
         let h0 = self.p0
         let h1 = self.p1
@@ -177,7 +177,7 @@ public struct CubicBezierCurve: NonlinearBezierCurve, ArcApproximateable, Equata
     }
 
     public func split(at t: CGFloat) -> (left: CubicBezierCurve, right: CubicBezierCurve) {
-        
+
         let h0 = self.p0
         let h1 = self.p1
         let h2 = self.p2
@@ -188,28 +188,28 @@ public struct CubicBezierCurve: NonlinearBezierCurve, ArcApproximateable, Equata
         let h7 = Utils.lerp(t, h4, h5)
         let h8 = Utils.lerp(t, h5, h6)
         let h9 = Utils.lerp(t, h7, h8)
-        
+
         let leftCurve  = CubicBezierCurve(p0: h0, p1: h4, p2: h7, p3: h9)
         let rightCurve = CubicBezierCurve(p0: h9, p1: h8, p2: h6, p3: h3)
-        
+
         return (left: leftCurve, right: rightCurve)
 
     }
-    
+
     public var boundingBox: BoundingBox {
 
         let p0: CGPoint = self.p0
         let p1: CGPoint = self.p1
         let p2: CGPoint = self.p2
         let p3: CGPoint = self.p3
-        
+
         var mmin = CGPoint.min(p0, p3)
         var mmax = CGPoint.max(p0, p3)
-        
+
         let d0 = p1 - p0
         let d1 = p2 - p1
         let d2 = p3 - p2
-        
+
         for d in 0..<CGPoint.dimensions {
             let mmind = mmin[d]
             let mmaxd = mmax[d]
@@ -230,12 +230,11 @@ public struct CubicBezierCurve: NonlinearBezierCurve, ArcApproximateable, Equata
         }
         return BoundingBox(min: mmin, max: mmax)
     }
-    
+
     public func compute(_ t: CGFloat) -> CGPoint {
         if t == 0 {
             return self.p0
-        }
-        else if t == 1 {
+        } else if t == 1 {
             return self.p3
         }
         let mt = 1.0 - t
@@ -259,7 +258,7 @@ extension CubicBezierCurve: Transformable {
         return CubicBezierCurve(p0: self.p0.applying(t), p1: self.p1.applying(t), p2: self.p2.applying(t), p3: self.p3.applying(t))
     }
 }
-    
+
 extension CubicBezierCurve: Reversible {
     public func reversed() -> CubicBezierCurve {
         return CubicBezierCurve(p0: self.p3, p1: self.p2, p2: self.p1, p3: self.p0)

--- a/BezierKit/Library/Draw.swift
+++ b/BezierKit/Library/Draw.swift
@@ -14,9 +14,9 @@ import UIKit
 
 // should Draw just be an extension of CGContext, or have a CGContext instead of passing it in to all these functions?
 public class Draw {
-    
+
     private static let deviceColorspace = CGColorSpaceCreateDeviceRGB()
-    
+
     // MARK: - helpers
     private static func Color(red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) -> CGColor {
         // have to use this initializer because simpler one is MacOS 10.5+ (not iOS)
@@ -28,7 +28,7 @@ public class Draw {
      * Adapted from: https://github.com/alessani/ColorConverter
      */
     internal static func HSLToRGB(h: CGFloat, s: CGFloat, l: CGFloat, outR: inout CGFloat, outG: inout CGFloat, outB: inout CGFloat) {
-        
+
         // Check for saturation. If there isn't any just return the luminance value for each, which results in gray.
         if s == 0.0 {
             outR = l
@@ -43,36 +43,31 @@ public class Draw {
         // Test for luminance and compute temporary values based on luminance and saturation
         if l < 0.5 {
             temp2 = l * (1.0 + s)
-        }
-        else {
+        } else {
             temp2 = l + s - l * s
         }
         temp1 = 2.0 * l - temp2
-        
+
         // Compute intermediate values based on hue
         temp[0] = h + 1.0 / 3.0
         temp[1] = h
         temp[2] = h - 1.0 / 3.0
-        
+
         for i in 0..<3 {
             // Adjust the range
             if temp[i] < 0.0 {
                 temp[i] += 1.0
-            }
-            else if temp[i] > 1.0 {
+            } else if temp[i] > 1.0 {
                 temp[i] -= 1.0
             }
-            
+
             if (6.0 * temp[i]) < 1.0 {
                 temp[i] = temp1 + (temp2 - temp1) * 6.0 * temp[i]
-            }
-            else if (2.0 * temp[i]) < 1.0 {
+            } else if (2.0 * temp[i]) < 1.0 {
                 temp[i] = temp2
-            }
-            else if (3.0 * temp[i]) < 2.0 {
+            } else if (3.0 * temp[i]) < 2.0 {
                 temp[i] = temp1 + (temp2 - temp1) * ((2.0 / 3.0) - temp[i]) * 6.0
-            }
-            else {
+            } else {
                 temp[i] = temp1
             }
         }
@@ -101,94 +96,91 @@ public class Draw {
             var g: CGFloat = 0.0
             var b: CGFloat = 0.0
             HSLToRGB(h: CGFloat(j) / 360.0, s: 0.5, l: 0.5, outR: &r, outG: &g, outB: &b)
-            
+
             temp.append(Draw.Color(red: r, green: g, blue: b, alpha: 1.0))
         }
         return temp
     }()
-    
+
     // MARK: -
-    
+
     public static func reset(_ context: CGContext) {
         context.setStrokeColor(black)
         randomIndex = 0
     }
-    
+
     // MARK: - setting colors
-    
+
     public static func setRandomColor(_ context: CGContext) {
         randomIndex = (randomIndex+1) % randomColors.count
         let c = randomColors[randomIndex]
         context.setStrokeColor(c)
     }
-    
+
     public static func setRandomFill(_ context: CGContext, alpha a: CGFloat = 1.0) {
         randomIndex = (randomIndex+1) % randomColors.count
         let c = randomColors[randomIndex]
         let c2 = c.copy(alpha: a)
         context.setFillColor(c2!)
     }
-    
+
     public static func setColor(_ context: CGContext, color: CGColor) {
         context.setStrokeColor(color)
     }
-    
+
     // MARK: - drawing various geometry
-    
+
     public static func drawCurve(_ context: CGContext, curve: BezierCurve, offset: CGPoint=CGPoint.zero) {
         context.beginPath()
         if let quadraticCurve = curve as? QuadraticBezierCurve {
             context.move(to: quadraticCurve.p0 + offset)
             context.addQuadCurve(to: quadraticCurve.p2 + offset,
                                  control: quadraticCurve.p1 + offset)
-        }
-        else if let cubicCurve = curve as? CubicBezierCurve {
+        } else if let cubicCurve = curve as? CubicBezierCurve {
             context.move(to: cubicCurve.p0 + offset)
             context.addCurve(to: cubicCurve.p3 + offset,
                              control1: cubicCurve.p1 + offset,
                              control2: cubicCurve.p2 + offset)
-        }
-        else if let lineSegment = curve as? LineSegment {
+        } else if let lineSegment = curve as? LineSegment {
             context.move(to: lineSegment.p0 + offset)
             context.addLine(to: lineSegment.p1 + offset)
-        }
-        else {
+        } else {
             fatalError("unsupported curve type")
         }
         context.strokePath()
     }
-    
-    public static func drawCircle(_ context: CGContext, center: CGPoint, radius r : CGFloat, offset: CGPoint = .zero) {
+
+    public static func drawCircle(_ context: CGContext, center: CGPoint, radius r: CGFloat, offset: CGPoint = .zero) {
         context.beginPath()
         context.addEllipse(in: CGRect(origin: CGPoint(x: center.x - r + offset.x, y: center.y - r + offset.y),
                             size: CGSize(width: 2.0 * r, height: 2.0 * r))
                             )
         context.strokePath()
     }
-    
+
     public static func drawPoint(_ context: CGContext, origin o: CGPoint, offset: CGPoint = .zero) {
         self.drawCircle(context, center: o, radius: 5.0, offset: offset)
-        
+
     }
-    
+
     public static func drawPoints(_ context: CGContext,
-                    points: [CGPoint],
-                    offset: CGPoint=CGPoint(x: 0.0, y: 0.0)) {
+                                  points: [CGPoint],
+                                  offset: CGPoint=CGPoint(x: 0.0, y: 0.0)) {
         for p in points {
             self.drawCircle(context, center: p, radius: 3.0, offset: offset)
         }
     }
-    
+
     public static func drawLine(_ context: CGContext,
-                  from p0: CGPoint,
-                  to p1: CGPoint,
-                  offset: CGPoint=CGPoint(x: 0.0, y: 0.0)) {
+                                from p0: CGPoint,
+                                to p1: CGPoint,
+                                offset: CGPoint=CGPoint(x: 0.0, y: 0.0)) {
         context.beginPath()
         context.move(to: p0 + offset)
         context.addLine(to: p1 + offset)
         context.strokePath()
     }
-    
+
     public static func drawText(_ context: CGContext, text: String, offset: CGPoint = .zero) {
     #if os(macOS)
         (text as NSString).draw(at: NSPoint(x: offset.x, y: offset.y), withAttributes: [:])
@@ -196,30 +188,29 @@ public class Draw {
         (text as NSString).draw(at: CGPoint(x: offset.x, y: offset.y), withAttributes: [:])
     #endif
     }
- 
+
     public static func drawSkeleton(_ context: CGContext,
-                             curve: BezierCurve,
-                             offset: CGPoint=CGPoint(x: 0.0, y: 0.0),
-                             coords: Bool=true) {
-        
+                                    curve: BezierCurve,
+                                    offset: CGPoint=CGPoint(x: 0.0, y: 0.0),
+                                    coords: Bool=true) {
+
         context.setStrokeColor(lightGrey)
-        
+
         if let cubicCurve = curve as? CubicBezierCurve {
             self.drawLine(context, from: cubicCurve.p0, to: cubicCurve.p1, offset: offset)
             self.drawLine(context, from: cubicCurve.p2, to: cubicCurve.p3, offset: offset)
-        }
-        else if let quadraticCurve = curve as? QuadraticBezierCurve {
+        } else if let quadraticCurve = curve as? QuadraticBezierCurve {
             self.drawLine(context, from: quadraticCurve.p0, to: quadraticCurve.p1, offset: offset)
             self.drawLine(context, from: quadraticCurve.p1, to: quadraticCurve.p2, offset: offset)
         }
-        
-        if (coords == true) {
+
+        if coords == true {
             context.setStrokeColor(black)
             self.drawPoints(context, points: curve.points, offset: offset)
         }
-        
+
     }
-    
+
     public static func draw(_ context: CGContext, arc: Arc, offset: CGPoint = .zero) {
         let o = offset
         context.beginPath()
@@ -232,8 +223,8 @@ public class Draw {
         context.addLine(to: arc.origin + o)
         context.drawPath(using: .fillStroke)
     }
-    
-    public static func drawHull(_ context: CGContext, hull: [CGPoint], offset : CGPoint = .zero) {
+
+    public static func drawHull(_ context: CGContext, hull: [CGPoint], offset: CGPoint = .zero) {
         context.beginPath()
         if hull.count == 6 {
             context.move(to: hull[0])
@@ -241,8 +232,7 @@ public class Draw {
             context.addLine(to: hull[2])
             context.move(to: hull[3])
             context.addLine(to: hull[4])
-        }
-        else {
+        } else {
             context.move(to: hull[0])
             context.addLine(to: hull[1])
             context.addLine(to: hull[2])
@@ -272,10 +262,9 @@ public class Draw {
             context.addCurve(to: offset + shape.forward.points[3],
                              control1: offset + shape.forward.points[1],
                              control2: offset + shape.forward.points[2]
-                             
+
             )
-        }
-        else {
+        } else {
             context.addQuadCurve(to: offset + shape.forward.points[2],
                                  control: offset + shape.forward.points[1]
             )
@@ -286,17 +275,16 @@ public class Draw {
                 control1: offset + shape.back.points[1],
                 control2: offset + shape.back.points[2]
             )
-        }
-        else {
+        } else {
             context.addQuadCurve(to: offset + shape.back.points[2],
                                  control: offset + shape.back.points[1]
             )
         }
         context.closePath()
         context.drawPath(using: .fillStroke)
-    
+
     }
-    
+
     public static func drawPathComponent(_ context: CGContext, pathComponent: PathComponent, offset: CGPoint = .zero, includeBoundingVolumeHierarchy: Bool = false) {
         if includeBoundingVolumeHierarchy {
             pathComponent.bvh.visit { node, depth in
@@ -312,7 +300,7 @@ public class Draw {
         context.addPath(pathComponent.cgPath)
         context.drawPath(using: .fillStroke)
     }
-    
+
     public static func drawPath(_ context: CGContext, _ path: Path, offset: CGPoint = .zero) {
         Draw.setRandomFill(context, alpha: 0.2)
         context.addPath(path.cgPath)

--- a/BezierKit/Library/LineSegment.swift
+++ b/BezierKit/Library/LineSegment.swift
@@ -11,22 +11,22 @@ import CoreGraphics
 public struct LineSegment: BezierCurve, Equatable {
 
     public var p0, p1: CGPoint
-    
+
     public init(points: [CGPoint]) {
         precondition(points.count == 2)
         self.p0 = points[0]
         self.p1 = points[1]
     }
-    
+
     public init(p0: CGPoint, p1: CGPoint) {
         self.p0 = p0
         self.p1 = p1
     }
-    
+
     public var points: [CGPoint] {
         return [p0, p1]
     }
-    
+
     public var startingPoint: CGPoint {
         get {
             return p0
@@ -35,7 +35,7 @@ public struct LineSegment: BezierCurve, Equatable {
             p0 = newValue
         }
     }
-    
+
     public var endingPoint: CGPoint {
         get {
             return p1
@@ -44,15 +44,15 @@ public struct LineSegment: BezierCurve, Equatable {
             p1 = newValue
         }
     }
-    
+
     public var order: Int {
         return 1
     }
-    
+
     public var simple: Bool {
         return true
     }
-    
+
     public func derivative(_ t: CGFloat) -> CGPoint {
         return self.p1 - self.p0
     }
@@ -60,14 +60,14 @@ public struct LineSegment: BezierCurve, Equatable {
     public func normal(_ t: CGFloat) -> CGPoint {
         return (self.p1 - self.p0).perpendicular.normalize()
     }
-    
+
     public func split(from t1: CGFloat, to t2: CGFloat) -> LineSegment {
         let p0 = self.p0
         let p1 = self.p1
         return LineSegment(p0: Utils.lerp(t1, p0, p1),
                            p1: Utils.lerp(t2, p0, p1))
     }
-    
+
     public func split(at t: CGFloat) -> (left: LineSegment, right: LineSegment) {
         let p0  = self.p0
         let p1  = self.p1
@@ -76,27 +76,27 @@ public struct LineSegment: BezierCurve, Equatable {
         let right = LineSegment(p0: mid, p1: p1)
         return (left: left, right: right)
     }
-    
+
     public var boundingBox: BoundingBox {
         let p0: CGPoint = self.p0
         let p1: CGPoint = self.p1
         return BoundingBox(min: CGPoint.min(p0, p1), max: CGPoint.max(p0, p1))
     }
-    
+
     public func compute(_ t: CGFloat) -> CGPoint {
         return Utils.lerp(t, self.p0, self.p1)
     }
-    
+
     // -- MARK: - overrides
-    
+
     public func length() -> CGFloat {
         return (self.p1 - self.p0).length
     }
-    
+
     public func extrema() -> (xyz: [[CGFloat]], values: [CGFloat] ) {
         return (xyz: [], [])
     }
-            
+
     public func project(_ point: CGPoint) -> (point: CGPoint, t: CGFloat) {
         // optimized implementation for line segments can be directly computed
         // default project implementation is found in BezierCurve protocol extension

--- a/BezierKit/Library/Lock.swift
+++ b/BezierKit/Library/Lock.swift
@@ -1,0 +1,17 @@
+//
+//  Lock.swift
+//  BezierKit
+//
+//  Created by Holmes Futrell on 5/24/19.
+//  Copyright © 2019 Holmes Futrell. All rights reserved.
+//
+
+import Foundation
+
+internal extension os_unfair_lock_s {
+    mutating func sync<T>(_ f: () throws -> T) rethrows -> T {
+        os_unfair_lock_lock(&self)
+        defer { os_unfair_lock_unlock(&self) }
+        return try f()
+    }
+}

--- a/BezierKit/Library/Path+Data.swift
+++ b/BezierKit/Library/Path+Data.swift
@@ -92,8 +92,7 @@ fileprivate extension InputStream {
                     currentPoints = []
                     currentOrders = []
                 }
-            }
-            else {
+            } else {
                 currentOrders.append(pointsToRead)
             }
             for _ in 0..<pointsToRead {
@@ -111,7 +110,7 @@ fileprivate extension InputStream {
         self.init(components: components)
     }
 
-    @objc var data: Data {
+    var data: Data {
 
         let expectedCoordinatesCount = 2 * self.components.reduce(0) { $0 + $1.points.count }
         let expectedCommandsCount = self.components.reduce(0) { $0 + $1.elementCount } + self.components.count

--- a/BezierKit/Library/Path.swift
+++ b/BezierKit/Library/Path.swift
@@ -189,7 +189,7 @@ internal func windingCountImpliesContainment(_ count: Int, using rule: PathFillR
     }
 
     convenience public init(curve: BezierCurve) {
-        self.init(components: [PathComponent(curves: [curve])])
+        self.init(components: [PathComponent(curve: curve)])
     }
 
     // MARK: - NSCoding

--- a/BezierKit/Library/Path.swift
+++ b/BezierKit/Library/Path.swift
@@ -47,9 +47,6 @@ internal func windingCountImpliesContainment(_ count: Int, using rule: PathFillR
                 currentComponentPoints = [self.currentPoint!]
             }
         }
-        func finishUp() {
-            self.completeComponentIfNeededAndClearPointsAndOrders()
-        }
     }
     
     @objc(CGPath) public lazy var cgPath: CGPath = {

--- a/BezierKit/Library/PathComponent.swift
+++ b/BezierKit/Library/PathComponent.swift
@@ -9,18 +9,6 @@
 import CoreGraphics
 import Foundation
 
-#if os(macOS)
-private extension NSValue { // annoying but MacOS (unlike iOS) doesn't have NSValue.cgPointValue available
-    var cgPointValue: CGPoint {
-        let pointValue: NSPoint = self.pointValue
-        return CGPoint(x: pointValue.x, y: pointValue.y)
-    }
-    convenience init(cgPoint: CGPoint) {
-        self.init(point: NSPoint(x: cgPoint.x, y: cgPoint.y))
-    }
-}
-#endif
-
 @objc(BezierKitPathComponent) open class PathComponent: NSObject, Reversible, Transformable {
     
     private let offsets: [Int]

--- a/BezierKit/Library/PathComponent.swift
+++ b/BezierKit/Library/PathComponent.swift
@@ -390,6 +390,11 @@ import Foundation
             let element = self.element(at: $0.elementIndex)
             let t = $0.t
             let dotProduct = Double(delta.dot(element.normal(t)))
+
+            if (element.compute(t) - point).dot(delta) > 0 {
+                return
+            }
+
             if dotProduct < 0 {
                 if t != 0 || !intersections.contains(IndexedPathComponentLocation(elementIndex: Utils.mod($0.elementIndex-1, self.elementCount), t: 1.0)) {
                     windingCount -= 1

--- a/BezierKit/Library/PathComponent.swift
+++ b/BezierKit/Library/PathComponent.swift
@@ -140,6 +140,10 @@ import Foundation
         self.offsets = PathComponent.computeOffsets(from: self.orders)
     }
 
+    convenience public init(curve: BezierCurve) {
+        self.init(curves: [curve])
+    }
+
     private static func computeOffsets(from orders: [Int]) -> [Int] {
         var offsets = [Int]()
         offsets.reserveCapacity(orders.count)

--- a/BezierKit/Library/PathComponent.swift
+++ b/BezierKit/Library/PathComponent.swift
@@ -391,11 +391,11 @@ import Foundation
             let t = $0.t
             let dotProduct = Double(delta.dot(element.normal(t)))
             if dotProduct < -Utils.epsilon {
-                if t != 0 {
+                if t != 0 || !intersections.contains(IndexedPathComponentLocation(elementIndex: Utils.mod($0.elementIndex-1, self.elementCount), t: 1.0)) {
                     windingCount -= 1
                 }
             } else if dotProduct > Utils.epsilon {
-                if t != 1 {
+                if t != 1 || !intersections.contains(IndexedPathComponentLocation(elementIndex: Utils.mod($0.elementIndex+1, self.elementCount), t: 0.0)) {
                     windingCount += 1
                 }
             }

--- a/BezierKit/Library/PathComponent.swift
+++ b/BezierKit/Library/PathComponent.swift
@@ -382,6 +382,7 @@ import Foundation
             return 0
         }
         // TODO: it's frustrating that this winding count uses a different logic than the one in augmented graph
+        // TODO: the test `testContainsRealWorldEdgeCase2` passes with the fix that checks "!intersections.contains" but we likely have the same issue when doing vector boolean ops with path element intersections (we need to ensure that if we filter t=0 intersections that we do actually catch them with the neighboring element!
         let line = LineSegment(p0: point, p1: CGPoint(x: self.boundingBox.min.x - self.boundingBox.size.x, y: point.y)) // horizontal line from point out of bounding box
         let delta = (line.p0 - line.p1).normalize()
         let intersections = self.intersects(line: line)

--- a/BezierKit/Library/PathComponent.swift
+++ b/BezierKit/Library/PathComponent.swift
@@ -382,7 +382,6 @@ import Foundation
             return 0
         }
         // TODO: it's frustrating that this winding count uses a different logic than the one in augmented graph
-        // TODO: the test `testContainsRealWorldEdgeCase2` passes with the fix that checks "!intersections.contains" but we likely have the same issue when doing vector boolean ops with path element intersections (we need to ensure that if we filter t=0 intersections that we do actually catch them with the neighboring element!
         let line = LineSegment(p0: point, p1: CGPoint(x: self.boundingBox.min.x - self.boundingBox.size.x, y: point.y)) // horizontal line from point out of bounding box
         let delta = (line.p0 - line.p1).normalize()
         let intersections = self.intersects(line: line)
@@ -391,11 +390,11 @@ import Foundation
             let element = self.element(at: $0.elementIndex)
             let t = $0.t
             let dotProduct = Double(delta.dot(element.normal(t)))
-            if dotProduct < -Utils.epsilon {
+            if dotProduct < 0 {
                 if t != 0 || !intersections.contains(IndexedPathComponentLocation(elementIndex: Utils.mod($0.elementIndex-1, self.elementCount), t: 1.0)) {
                     windingCount -= 1
                 }
-            } else if dotProduct > Utils.epsilon {
+            } else if dotProduct > 0 {
                 if t != 1 || !intersections.contains(IndexedPathComponentLocation(elementIndex: Utils.mod($0.elementIndex+1, self.elementCount), t: 0.0)) {
                     windingCount += 1
                 }

--- a/BezierKit/Library/PathComponent.swift
+++ b/BezierKit/Library/PathComponent.swift
@@ -381,7 +381,7 @@ import Foundation
         guard self.isClosed, self.boundingBox.contains(point) else {
             return 0
         }
-        // TODO: assumes element.normal() is always defined, which unfortunately it's not (eg degenerate curves as points, cusps, zero derivatives at the end of curves)
+        // TODO: it's frustrating that this winding count uses a different logic than the one in augmented graph
         let line = LineSegment(p0: point, p1: CGPoint(x: self.boundingBox.min.x - self.boundingBox.size.x, y: point.y)) // horizontal line from point out of bounding box
         let delta = (line.p0 - line.p1).normalize()
         let intersections = self.intersects(line: line)
@@ -389,7 +389,6 @@ import Foundation
         intersections.forEach {
             let element = self.element(at: $0.elementIndex)
             let t = $0.t
-            assert(element.normal($0.t).x.isFinite && element.normal($0.t).y.isFinite, "possible NaN normal vector. Possible data for unit test?")
             let dotProduct = Double(delta.dot(element.normal(t)))
             if dotProduct < -Utils.epsilon {
                 if t != 0 {

--- a/BezierKit/Library/QuadraticBezierCurve.swift
+++ b/BezierKit/Library/QuadraticBezierCurve.swift
@@ -9,37 +9,35 @@
 import CoreGraphics
 
 public struct QuadraticBezierCurve: NonlinearBezierCurve, ArcApproximateable, Equatable {
-    
+
     public var p0, p1, p2: CGPoint
-    
+
     public init(points: [CGPoint]) {
         precondition(points.count == 3)
         self.p0 = points[0]
         self.p1 = points[1]
         self.p2 = points[2]
     }
-    
+
     public init(p0: CGPoint, p1: CGPoint, p2: CGPoint) {
         self.p0 = p0
         self.p1 = p1
         self.p2 = p2
     }
-    
+
     public init(lineSegment l: LineSegment) {
         self.init(p0: l.p0, p1: 0.5 * (l.p0 + l.p1), p2: l.p1)
     }
-    
+
     public init(start: CGPoint, end: CGPoint, mid: CGPoint, t: CGFloat = 0.5) {
         // shortcuts, although they're really dumb
         if t == 0 {
             self.init(p0: mid, p1: mid, p2: end)
-        }
-        else if t == 1 {
+        } else if t == 1 {
             self.init(p0: start, p1: mid, p2: mid)
-        }
-        else {
+        } else {
             // real fitting.
-            let abc = Utils.getABC(n:2, S: start, B: mid, E: end, t: t)
+            let abc = Utils.getABC(n: 2, S: start, B: mid, E: end, t: t)
             self.init(p0: start, p1: abc.A, p2: end)
         }
     }
@@ -47,7 +45,7 @@ public struct QuadraticBezierCurve: NonlinearBezierCurve, ArcApproximateable, Eq
     public var points: [CGPoint] {
         return [p0, p1, p2]
     }
-    
+
     public var startingPoint: CGPoint {
         get {
             return p0
@@ -56,7 +54,7 @@ public struct QuadraticBezierCurve: NonlinearBezierCurve, ArcApproximateable, Eq
             p0 = newValue
         }
     }
-    
+
     public var endingPoint: CGPoint {
         get {
             return p2
@@ -65,11 +63,11 @@ public struct QuadraticBezierCurve: NonlinearBezierCurve, ArcApproximateable, Eq
             p2 = newValue
         }
     }
-    
+
     public var order: Int {
         return 2
     }
-    
+
     public var simple: Bool {
         guard p0 != p1 || p1 != p2 else { return true }
         let n1 = self.normal(0)
@@ -90,7 +88,7 @@ public struct QuadraticBezierCurve: NonlinearBezierCurve, ArcApproximateable, Eq
         }
         return d.perpendicular.normalize()
     }
-    
+
     public func derivative(_ t: CGFloat) -> CGPoint {
         let mt: CGFloat = 1-t
         let k: CGFloat = 2
@@ -121,25 +119,25 @@ public struct QuadraticBezierCurve: NonlinearBezierCurve, ArcApproximateable, Eq
         let h3 = Utils.lerp(t, h0, h1)
         let h4 = Utils.lerp(t, h1, h2)
         let h5 = Utils.lerp(t, h3, h4)
-        
+
         let leftCurve = QuadraticBezierCurve(p0: h0, p1: h3, p2: h5)
         let rightCurve = QuadraticBezierCurve(p0: h5, p1: h4, p2: h2)
-    
+
         return (left: leftCurve, right: rightCurve)
     }
 
     public var boundingBox: BoundingBox {
-        
+
         let p0: CGPoint = self.p0
         let p1: CGPoint = self.p1
         let p2: CGPoint = self.p2
-        
+
         var mmin: CGPoint = CGPoint.min(p0, p2)
         var mmax: CGPoint = CGPoint.max(p0, p2)
-        
+
         let d0: CGPoint = p1 - p0
         let d1: CGPoint = p2 - p1
-        
+
         for d in 0..<CGPoint.dimensions {
             Utils.droots(d0[d], d1[d]) {(t: CGFloat) in
                 guard t > 0.0, t < 1.0 else {
@@ -159,8 +157,7 @@ public struct QuadraticBezierCurve: NonlinearBezierCurve, ArcApproximateable, Eq
     public func compute(_ t: CGFloat) -> CGPoint {
         if t == 0 {
             return self.p0
-        }
-        else if t == 1 {
+        } else if t == 1 {
             return self.p2
         }
         let mt = 1.0 - t

--- a/BezierKit/Library/Shape.swift
+++ b/BezierKit/Library/Shape.swift
@@ -29,13 +29,13 @@ public struct Shape: Equatable {
             return lhs.curve == rhs.curve && lhs.virtual == rhs.virtual
         }
     }
-    
+
     public static let defaultShapeIntersectionThreshold: CGFloat = 0.5
     public let startcap: Cap
     public let endcap: Cap
     public let forward: BezierCurve
     public let back: BezierCurve
-    
+
     internal init(_ forward: BezierCurve, _ back: BezierCurve, _ startCapVirtual: Bool, _ endCapVirtual: Bool) {
         let start  = LineSegment(p0: back.endingPoint, p1: forward.startingPoint)
         let end    = LineSegment(p0: forward.endingPoint, p1: back.startingPoint)
@@ -44,7 +44,7 @@ public struct Shape: Equatable {
         self.forward = forward
         self.back = back
     }
-    
+
     public var boundingBox: BoundingBox {
         return self.nonvirtualSegments().reduce(BoundingBox.empty) {
             BoundingBox(first: $0, second: $1.boundingBox)
@@ -64,7 +64,7 @@ public struct Shape: Equatable {
         }
         return segments
     }
-    
+
     public func intersects(shape other: Shape, accuracy: CGFloat = BezierKit.defaultIntersectionAccuracy) -> [ShapeIntersection] {
         if self.boundingBox.overlaps(other.boundingBox) == false {
             return []
@@ -82,7 +82,7 @@ public struct Shape: Equatable {
         }
         return intersections
     }
-    
+
     public static func == (lhs: Shape, rhs: Shape) -> Bool {
         return lhs.startcap == rhs.startcap && lhs.endcap == rhs.endcap && lhs.forward == rhs.forward && lhs.back == rhs.back
     }

--- a/BezierKit/Library/Types.swift
+++ b/BezierKit/Library/Types.swift
@@ -18,11 +18,9 @@ public struct Intersection: Equatable, Comparable {
     public static func < (lhs: Intersection, rhs: Intersection ) -> Bool {
         if lhs.t1 < rhs.t1 {
             return true
-        }
-        else if lhs.t1 == rhs.t1 {
+        } else if lhs.t1 == rhs.t1 {
             return lhs.t2 < rhs.t2
-        }
-        else {
+        } else {
             return false
         }
     }

--- a/BezierKit/Library/Utils.swift
+++ b/BezierKit/Library/Utils.swift
@@ -18,7 +18,7 @@ internal class Utils {
     static let epsilon: Double = 1.0e-5
     static let tau: Double = 2.0 * Double.pi
     static let quart: Double = Double.pi / 2.0
-    
+
     // Legendre-Gauss abscissae with n=24 (x_i values, defined at i=n as the roots of the nth order Legendre polynomial Pn(x))
     static let Tvalues: ContiguousArray<CGFloat> = [
         -0.0640568928626056260850430826247450385909,
@@ -46,7 +46,7 @@ internal class Utils {
         -0.9951872199970213601799974097007368118745,
         0.9951872199970213601799974097007368118745
     ]
-    
+
     // Legendre-Gauss weights with n=24 (w_i values, defined by a function linked to in the Bezier primer article)
     static let Cvalues: ContiguousArray<CGFloat> = [
         0.1279381953467521569740561652246953718517,
@@ -74,7 +74,7 @@ internal class Utils {
         0.0123412297999871995468056670700372915759,
         0.0123412297999871995468056670700372915759
     ]
-    
+
     static func getABC(n: Int, S: CGPoint, B: CGPoint, E: CGPoint, t: CGFloat = 0.5) -> (A: CGPoint, B: CGPoint, C: CGPoint) {
         let u = Utils.projectionRatio(n: n, t: t)
         let um = 1-u
@@ -89,42 +89,42 @@ internal class Utils {
         )
         return ( A:A, B:B, C:C )
     }
-    
+
     static func abcRatio(n: Int, t: CGFloat = 0.5) -> CGFloat {
         // see ratio(t) note on http://pomax.github.io/bezierinfo/#abc
         assert(n == 2 || n == 3)
-        if ( t == 0 || t == 1) {
+        if t == 0 || t == 1 {
             return t
         }
         let bottom = pow(t, CGFloat(n)) + pow(1 - t, CGFloat(n))
         let top = bottom - 1
         return abs(top/bottom)
     }
-    
+
     static func projectionRatio(n: Int, t: CGFloat = 0.5) -> CGFloat {
         // see u(t) note on http://pomax.github.io/bezierinfo/#abc
         assert(n == 2 || n == 3)
-        if (t == 0 || t == 1) {
+        if t == 0 || t == 1 {
             return t
         }
         let top = pow(1.0 - t, CGFloat(n))
         let bottom = pow(t, CGFloat(n)) + top
         return top/bottom
     }
-    
-    static func map(_ v: CGFloat,_ ds: CGFloat,_ de: CGFloat,_ ts: CGFloat,_ te: CGFloat) -> CGFloat {
+
+    static func map(_ v: CGFloat, _ ds: CGFloat, _ de: CGFloat, _ ts: CGFloat, _ te: CGFloat) -> CGFloat {
         let d1 = de-ds
         let d2 = te-ts
         let v2 = v-ds
         let r = v2/d1
-        return ts + d2*r        
+        return ts + d2*r
     }
 
-    static func approximately(_ a: Double,_ b: Double, precision: Double) -> Bool {
+    static func approximately(_ a: Double, _ b: Double, precision: Double) -> Bool {
         return abs(a-b) <= precision
     }
-    
-    static func linesIntersection(_ line1p1: CGPoint,_ line1p2: CGPoint,_ line2p1: CGPoint,_ line2p2: CGPoint) -> CGPoint? {
+
+    static func linesIntersection(_ line1p1: CGPoint, _ line1p2: CGPoint, _ line2p1: CGPoint, _ line2p2: CGPoint) -> CGPoint? {
         let x1 = line1p1.x; let y1 = line1p1.y
         let x2 = line1p2.x; let y2 = line1p2.y
         let x3 = line2p1.x; let y3 = line2p1.y
@@ -138,12 +138,12 @@ internal class Utils {
         let n = a * (line2p1 - line2p2) - b * (line1p1 - line1p2)
         return (1.0 / d) * n
     }
-    
+
     // cube root function yielding real roots
     static private func crt(_ v: Double) -> Double {
-        return (v < 0) ? -pow(-v,1.0/3.0) : pow(v,1.0/3.0)
+        return (v < 0) ? -pow(-v, 1.0/3.0) : pow(v, 1.0/3.0)
     }
-    
+
     static func clamp(_ x: CGFloat, _ a: CGFloat, _ b: CGFloat) -> CGFloat {
         precondition(b >= a)
         if x < a {
@@ -154,27 +154,24 @@ internal class Utils {
             return x
         }
     }
-    
+
     static func roots(points: [CGPoint], line: LineSegment) -> [CGFloat] {
         let order = points.count - 1
         let p = Utils.align(points, p1: line.p0, p2: line.p1)
-        
+
         let clamp: (Double) -> CGFloat? = {
             if $0 < -epsilon {
                 return nil
-            }
-            else if $0 > 1.0 + epsilon {
+            } else if $0 > 1.0 + epsilon {
                 return nil
-            }
-            else if Utils.approximately($0, 0.0, precision: epsilon) {
+            } else if Utils.approximately($0, 0.0, precision: epsilon) {
                 return CGFloat(0.0)
-            }
-            else if Utils.approximately($0, 1.0, precision: epsilon) {
+            } else if Utils.approximately($0, 1.0, precision: epsilon) {
                 return CGFloat(1.0)
             }
             return CGFloat($0)
         }
-        
+
         if order == 2 {
             let a = Double(p[0].y)
             let b = Double(p[1].y)
@@ -186,15 +183,12 @@ internal class Utils {
                 let v1: Double = -( m1+m2)/d
                 let v2: Double = -(-m1+m2)/d
                 return [v1, v2].compactMap(clamp)
-            }
-            else if a != b {
+            } else if a != b {
                 return [Double(0.5) * a / (a-b)].compactMap(clamp)
-            }
-            else {
+            } else {
                 return []
             }
-        }
-        else if order == 3 {
+        } else if order == 3 {
             // see http://www.trans4mind.com/personal_development/mathematics/polynomials/cubicAlgebra.htm
             let pa = Double(p[0].y)
             let pb = Double(p[1].y)
@@ -236,29 +230,25 @@ internal class Utils {
                 let x2 = t1 * cos((phi+tau)/3) - a/3
                 let x3 = t1 * cos((phi+2*tau)/3) - a/3
                 return [x1, x2, x3].compactMap(clamp)
-            }
-            else if discriminant > epsilon {
+            } else if discriminant > epsilon {
                 let sd = sqrt(discriminant)
                 let u1 = crt(-q2+sd)
                 let v1 = crt(q2+sd)
                 return [u1-v1-a/3].compactMap(clamp)
-            }
-            else if discriminant.isNaN == false {
+            } else if discriminant.isNaN == false {
                 let u1 = q2 < 0 ? crt(-q2) : -crt(q2)
                 let x1 = 2*u1-a/3
                 let x2 = -u1 - a/3
-                return [x1,x2].compactMap(clamp)
-            }
-            else {
+                return [x1, x2].compactMap(clamp)
+            } else {
                 return []
             }
-        }
-        else {
+        } else {
             fatalError("unsupported")
         }
     }
-    
-    static func droots(_ a: CGFloat, _ b: CGFloat, _ c: CGFloat, callback:(CGFloat) -> Void) {
+
+    static func droots(_ a: CGFloat, _ b: CGFloat, _ c: CGFloat, callback: (CGFloat) -> Void) {
         // quadratic roots are easy
         // do something with each root
         let d: CGFloat = a - 2.0*b + c
@@ -269,12 +259,11 @@ internal class Utils {
             let v2 = -(-m1+m2)/d
             callback(v1)
             callback(v2)
-        }
-        else if a != b {
+        } else if a != b {
             callback(0.5 * a / (a - b))
         }
     }
-    
+
     static func droots(_ a: CGFloat, _ b: CGFloat, callback: (CGFloat) -> Void) {
         // linear roots are super easy
         // do something with the root, if it exists
@@ -282,7 +271,7 @@ internal class Utils {
             callback(a/(a-b))
         }
     }
-    
+
     static func droots(_ p: [CGFloat]) -> [CGFloat] {
         // quadratic roots are easy
         var result: [CGFloat] = []
@@ -290,13 +279,11 @@ internal class Utils {
             droots(p[0], p[1], p[2]) {
                 result.append($0)
             }
-        }
-        else if p.count == 2 {
+        } else if p.count == 2 {
             droots(p[0], p[1]) {
                 result.append($0)
             }
-        }
-        else {
+        } else {
             fatalError("unsupported")
         }
         return result
@@ -307,20 +294,20 @@ internal class Utils {
         let r = a % n
         return r >= 0 ? r : r + n
     }
-    
+
     static func lerp(_ r: CGFloat, _ v1: CGPoint, _ v2: CGPoint) -> CGPoint {
         return v1 + r * (v2 - v1)
     }
-    
-    static func dist(_ p1: CGPoint,_ p2: CGPoint) -> CGFloat {
+
+    static func dist(_ p1: CGPoint, _ p2: CGPoint) -> CGFloat {
         return (p1 - p2).length
     }
-    
+
     static func arcfn(_ t: CGFloat, _ derivativeFn: (_ t: CGFloat) -> CGPoint) -> CGFloat {
         let d = derivativeFn(t)
         return d.length
     }
-    
+
     static func length(_ derivativeFn: (_ t: CGFloat) -> CGPoint) -> CGFloat {
         let z: CGFloat = 0.5
         let len = Utils.Tvalues.count
@@ -331,13 +318,13 @@ internal class Utils {
         }
         return z * sum
     }
-    
+
     static func angle(o: CGPoint, v1: CGPoint, v2: CGPoint) -> CGFloat {
         let d1 = v1 - o
         let d2 = v2 - o
         return atan2(d1.cross(d2), d1.dot(d2))
     }
-    
+
     static func align(_ points: [CGPoint], p1: CGPoint, p2: CGPoint) -> [CGPoint] {
         let lineDirection = (p2 - p1).normalize()
         return points.map {
@@ -353,7 +340,7 @@ internal class Utils {
                                       _ c1b: BoundingBox, _ c2b: BoundingBox,
                                       _ results: inout [Intersection],
                                       _ accuracy: CGFloat) {
-        
+
         guard results.count < c1.curve.order * c2.curve.order else { return }
         guard c1b.overlaps(c2b) else { return }
 
@@ -371,8 +358,7 @@ internal class Utils {
             let t2 = intersection.t2
             results.append(Intersection(t1: t1 * c1.t2 + (1.0 - t1) * c1.t1,
                                         t2: t2 * c2.t2 + (1.0 - t2) * c2.t1))
-        }
-        else if shouldRecurse1, shouldRecurse2 {
+        } else if shouldRecurse1, shouldRecurse2 {
             let cc1 = c1.split(at: 0.5)
             let cc2 = c2.split(at: 0.5)
             let cc1lb = cc1.left.curve.boundingBox
@@ -383,15 +369,13 @@ internal class Utils {
             Utils.pairiteration(cc1.left, cc2.right, cc1lb, cc2rb, &results, accuracy)
             Utils.pairiteration(cc1.right, cc2.left, cc1rb, cc2lb, &results, accuracy)
             Utils.pairiteration(cc1.right, cc2.right, cc1rb, cc2rb, &results, accuracy)
-        }
-        else if shouldRecurse1 {
+        } else if shouldRecurse1 {
             let cc1 = c1.split(at: 0.5)
             let cc1lb = cc1.left.curve.boundingBox
             let cc1rb = cc1.right.curve.boundingBox
             Utils.pairiteration(cc1.left, c2, cc1lb, c2b, &results, accuracy)
             Utils.pairiteration(cc1.right, c2, cc1rb, c2b, &results, accuracy)
-        }
-        else if shouldRecurse2 {
+        } else if shouldRecurse2 {
             let cc2 = c2.split(at: 0.5)
             let cc2lb = cc2.left.curve.boundingBox
             let cc2rb = cc2.right.curve.boundingBox
@@ -399,7 +383,7 @@ internal class Utils {
             Utils.pairiteration(c1, cc2.right, c1b, cc2rb, &results, accuracy)
         }
     }
-            
+
     static func getccenter( _ p1: CGPoint, _ p2: CGPoint, _ p3: CGPoint, _ interval: Interval) -> Arc {
         let d1 = p2 - p1
         let d2 = p3 - p2
@@ -415,9 +399,9 @@ internal class Utils {
         let m2n = m2 + d2p
         // intersection of these lines:
         let oo = Utils.linesIntersection(m1, m1n, m2, m2n)
-        
+
         assert(oo != nil)
-        
+
         let o: CGPoint = oo!
         let r = Utils.dist(o, p1)
         // arc start/end values, over mid point:
@@ -435,31 +419,29 @@ internal class Utils {
             if s>e {
                 swap(&s, &e)
             }
-        }
-        else {
+        } else {
             // if e<m<s, arc(e, s)
             // if m<e<s, arc(s, e + tau)
             // if e<s<m, arc(s, e + tau)
             if e<m && m<s {
                 swap(&s, &e)
-            }
-            else {
+            } else {
                 e += CGFloat(tau)
             }
         }
         return Arc(origin: o, radius: r, startAngle: s, endAngle: e, interval: interval)
     }
-    
+
     static func hull(_ p: [CGPoint], _ t: CGFloat) -> [CGPoint] {
         let c: Int = p.count
         var q: [CGPoint] = p
         q.reserveCapacity(c * (c+1) / 2) // reserve capacity ahead of time to avoid re-alloc
         // we lerp between all points (in-place), until we have 1 point left.
         var start: Int = 0
-        for count in (1 ..< c).reversed()  {
+        for count in (1 ..< c).reversed() {
             let end: Int = start + count
             for i in start ..< end {
-                let pt = Utils.lerp(t,q[i],q[i+1])
+                let pt = Utils.lerp(t, q[i], q[i+1])
                 q.append(pt)
             }
             start = end + 1

--- a/BezierKit/Library/Utils.swift
+++ b/BezierKit/Library/Utils.swift
@@ -198,7 +198,8 @@ internal class Utils {
             let temp2 = 3*pb
             let temp3 = -3*pc
             let d = temp1 + temp2 + temp3 + pd
-            if abs(d) < Utils.epsilon {
+            let smallValue = 1.0e-10
+            if abs(d) < smallValue {
                 let temp1 = 3*points[0]
                 let temp2 = -6*points[1]
                 let temp3 = 3*points[2]
@@ -217,7 +218,7 @@ internal class Utils {
             let q = (2*a*a*a - 9*a*b + 27*c)/27
             let q2 = q/2
             let discriminant = q2*q2 + p3*p3*p3
-            if discriminant < -epsilon {
+            if discriminant < -smallValue {
                 let mp3 = -p/3
                 let mp33 = mp3*mp3*mp3
                 let r = sqrt( mp33 )
@@ -230,7 +231,7 @@ internal class Utils {
                 let x2 = t1 * cos((phi+tau)/3) - a/3
                 let x3 = t1 * cos((phi+2*tau)/3) - a/3
                 return [x1, x2, x3].compactMap(clamp)
-            } else if discriminant > epsilon {
+            } else if discriminant > smallValue {
                 let sd = sqrt(discriminant)
                 let u1 = crt(-q2+sd)
                 let v1 = crt(q2+sd)

--- a/BezierKit/Library/Utils.swift
+++ b/BezierKit/Library/Utils.swift
@@ -155,22 +155,9 @@ internal class Utils {
         }
     }
 
-    static func roots(points: [CGPoint], line: LineSegment) -> [CGFloat] {
+    static func roots(points: [CGPoint], line: LineSegment) -> [Double] {
         let order = points.count - 1
         let p = Utils.align(points, p1: line.p0, p2: line.p1)
-
-        let clamp: (Double) -> CGFloat? = {
-            if $0 < -epsilon {
-                return nil
-            } else if $0 > 1.0 + epsilon {
-                return nil
-            } else if Utils.approximately($0, 0.0, precision: epsilon) {
-                return CGFloat(0.0)
-            } else if Utils.approximately($0, 1.0, precision: epsilon) {
-                return CGFloat(1.0)
-            }
-            return CGFloat($0)
-        }
 
         if order == 2 {
             let a = Double(p[0].y)
@@ -182,9 +169,9 @@ internal class Utils {
                 let m2 = -a+b
                 let v1: Double = -( m1+m2)/d
                 let v2: Double = -(-m1+m2)/d
-                return [v1, v2].compactMap(clamp)
+                return [v1, v2]
             } else if a != b {
-                return [Double(0.5) * a / (a-b)].compactMap(clamp)
+                return [Double(0.5) * a / (a-b)]
             } else {
                 return []
             }
@@ -230,17 +217,17 @@ internal class Utils {
                 let x1 = t1 * cos(phi/3) - a/3
                 let x2 = t1 * cos((phi+tau)/3) - a/3
                 let x3 = t1 * cos((phi+2*tau)/3) - a/3
-                return [x1, x2, x3].compactMap(clamp)
+                return [x1, x2, x3]
             } else if discriminant > smallValue {
                 let sd = sqrt(discriminant)
                 let u1 = crt(-q2+sd)
                 let v1 = crt(q2+sd)
-                return [u1-v1-a/3].compactMap(clamp)
+                return [u1-v1-a/3]
             } else if discriminant.isNaN == false {
                 let u1 = q2 < 0 ? crt(-q2) : -crt(q2)
                 let x1 = 2*u1-a/3
                 let x2 = -u1 - a/3
-                return [x1, x2].compactMap(clamp)
+                return [x1, x2]
             } else {
                 return []
             }

--- a/BezierKit/MacDemos/AppDelegate.swift
+++ b/BezierKit/MacDemos/AppDelegate.swift
@@ -13,7 +13,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @IBOutlet weak var window: NSWindow!
 
-
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Insert code here to initialize your application
     }
@@ -22,6 +21,4 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Insert code here to tear down your application
     }
 
-
 }
-

--- a/BezierKit/MacDemos/Demos.swift
+++ b/BezierKit/MacDemos/Demos.swift
@@ -33,7 +33,7 @@ class Demos {
     private static let quadraticControlPoints = [CGPoint(x: 150, y: 40),
                                          CGPoint(x: 80, y: 30),
                                          CGPoint(x: 105, y: 150)]
-    
+
     static let demo1 = Demo(title: "new Bezier(...)",
                             quadraticControlPoints: quadraticControlPoints,
                             cubicControlPoints: cubicControlPoints,
@@ -41,7 +41,7 @@ class Demos {
                                 let curve = demoState.curve!
                                 Draw.drawSkeleton(context, curve: curve)
                                 Draw.drawCurve(context, curve: curve)
-                                
+
     })
     static let demo2 = Demo(title: "Bezier.quadraticFromPoints",
                             quadraticControlPoints: [],
@@ -51,12 +51,12 @@ class Demos {
                                     let B = CGPoint(x: 100, y: 50)
                                     let tvalues: [CGFloat] = [0.2, 0.3, 0.4, 0.5]
                                     let curves: [QuadraticBezierCurve] = tvalues.map({(t: CGFloat) -> QuadraticBezierCurve in
-                                        return QuadraticBezierCurve(start: CGPoint(x:150, y: 40),
-                                                                    end: CGPoint(x:35, y:160),
+                                        return QuadraticBezierCurve(start: CGPoint(x: 150, y: 40),
+                                                                    end: CGPoint(x: 35, y: 160),
                                                                     mid: B,
                                                                     t: t)
                                     })
-                                    let offset = CGPoint(x:45,y:30)
+                                    let offset = CGPoint(x: 45, y: 30)
                                     for (i, b) in curves.enumerated() {
                                         Draw.drawSkeleton(context, curve: b, offset: offset, coords: true)
                                         Draw.setColor(context, color: Draw.transparentBlack)
@@ -69,20 +69,15 @@ class Demos {
                                         Draw.drawCurve(context, curve: b, offset: offset)
                                     }
                                     Draw.setColor(context, color: Draw.black)
-                                    Draw.drawCircle(context, center: curves[0].points[0], radius:3, offset: offset)
-                                    Draw.drawCircle(context, center: curves[0].points[2], radius:3, offset: offset)
+                                    Draw.drawCircle(context, center: curves[0].points[0], radius: 3, offset: offset)
+                                    Draw.drawCircle(context, center: curves[0].points[2], radius: 3, offset: offset)
                                     Draw.drawCircle(context, center: B, radius: 3, offset: offset)
-                                }
-                                else {
+                                } else {
                                     let p1 = CGPoint(x: 110, y: 50)
                                     let B = CGPoint(x: 50, y: 80)
-                                    let p3 = CGPoint(x:135, y:100)
+                                    let p3 = CGPoint(x: 135, y: 100)
                                     let tvalues: [CGFloat] = [0.2, 0.3, 0.4, 0.5]
-                                    let curves: [CubicBezierCurve] = tvalues.map({
-                                        (t: CGFloat) -> (CubicBezierCurve) in
-                                        return CubicBezierCurve(start: p1, end: p3, mid: B, t: t)
-                                        }
-                                    )
+                                    let curves = tvalues.map { CubicBezierCurve(start: p1, end: p3, mid: B, t: $0) }
                                     let offset = CGPoint(x: 0.0, y: 0.0)
                                     for curve in curves {
                                         Draw.setRandomColor(context)
@@ -119,7 +114,7 @@ class Demos {
                                 for idx in 0 ..< offset.count {
                                     let c = offset[idx]
                                     Draw.drawCurve(context, curve: c)
-                                    if(idx==last) {
+                                    if idx == last {
                                         let p1 = curve.offset(t: 0.95, distance: -15)
                                         let p2 = c.compute(1)
                                         let p3 = curve.offset(t: 0.95, distance: -5)
@@ -242,7 +237,7 @@ class Demos {
                                     Draw.drawCurve(context, curve: c)
                                 }
                                 Draw.drawPoint(context, origin: curve.offset(t: 0.5, distance: 25))
-                                
+
     })
     static let demo14 = Demo(title: ".reduce(t)",
                              quadraticControlPoints: quadraticControlPoints,
@@ -253,8 +248,7 @@ class Demos {
                                 if demoState.quadratic {
                                     let curve: QuadraticBezierCurve = demoState.curve! as! QuadraticBezierCurve
                                     reduced = curve.reduce().map({s in return s.curve})
-                                }
-                                else {
+                                } else {
                                     let curve: CubicBezierCurve = demoState.curve! as! CubicBezierCurve
                                     reduced = curve.reduce().map({s in return s.curve})
                                 }
@@ -294,8 +288,7 @@ class Demos {
                                 if demoState.quadratic {
                                     let curve: QuadraticBezierCurve = demoState.curve! as! QuadraticBezierCurve
                                     reduced = curve.reduce().map({s in return s.curve})
-                                }
-                                else {
+                                } else {
                                     let curve: CubicBezierCurve = demoState.curve! as! CubicBezierCurve
                                     reduced = curve.reduce().map({s in return s.curve})
                                 }
@@ -310,8 +303,7 @@ class Demos {
                                     for i in stride(from: -30, through: 30, by: 10) {
                                         Draw.drawCurve(context, curve: reduced[(reduced.count/2)].scale(distance: CGFloat(i)))
                                     }
-                                }
-                                else {
+                                } else {
                                     Draw.drawCurve(context, curve: curve)
                                 }
     })
@@ -333,7 +325,7 @@ class Demos {
                                 outline.offset(distance: 10).curves.forEach(doc)
                                 outline.offset(distance: -10).curves.forEach(doc)
     })
-    
+
     static let demo18 = Demo(title: "graduated outlines, using .outline(d1,d2,d3,d4)",
                              quadraticControlPoints: quadraticControlPoints,
                              cubicControlPoints: [CGPoint(x: 102, y: 33), CGPoint(x: 16, y: 99), CGPoint(x: 101, y: 129), CGPoint(x: 132, y: 173)],
@@ -376,13 +368,13 @@ class Demos {
                                 }
     })
     static let demo21  = Demo(title: ".intersections(with line: LineSegment)",
-                              quadraticControlPoints: [CGPoint(x: 58, y: 173),CGPoint(x: 26, y: 28), CGPoint(x: 163, y: 104)],
+                              quadraticControlPoints: [CGPoint(x: 58, y: 173), CGPoint(x: 26, y: 28), CGPoint(x: 163, y: 104)],
                               cubicControlPoints: [CGPoint(x: 53, y: 163), CGPoint(x: 27, y: 19), CGPoint(x: 182, y: 176), CGPoint(x: 155, y: 36)],
                               drawFunction: {(context: CGContext, demoState: DemoState) in
                                 let curve = demoState.curve!
                                 Draw.drawSkeleton(context, curve: curve)
                                 Draw.drawCurve(context, curve: curve)
-                                let line: LineSegment = LineSegment( p0: CGPoint(x:0.0, y:175.0), p1: CGPoint(x:200.0,y:25.0) )
+                                let line: LineSegment = LineSegment( p0: CGPoint(x: 0.0, y: 175.0), p1: CGPoint(x: 200.0, y: 25.0) )
                                 Draw.setColor(context, color: Draw.red)
                                 Draw.drawLine(context, from: line.p0, to: line.p1)
                                 Draw.setColor(context, color: Draw.black)
@@ -391,7 +383,7 @@ class Demos {
                                 }
     })
     static let demo22 = Demo(title: ".intersections(with curve: BezierCurve)",
-                             quadraticControlPoints: [CGPoint(x: 0, y: 0),CGPoint(x: 100, y: 187), CGPoint(x: 166, y: 37)],
+                             quadraticControlPoints: [CGPoint(x: 0, y: 0), CGPoint(x: 100, y: 187), CGPoint(x: 166, y: 37)],
                              cubicControlPoints: [CGPoint(x: 48, y: 84), CGPoint(x: 104, y: 176), CGPoint(x: 190, y: 37), CGPoint(x: 121, y: 75)],
                              drawFunction: {(context: CGContext, demoState: DemoState) in
                                 let curve = demoState.curve!
@@ -411,43 +403,43 @@ class Demos {
                              drawFunction: {(context: CGContext, demoState: DemoState) in
 
                                 Draw.reset(context)
-                                
+
                                 var flip = CGAffineTransform.init(scaleX: 1, y: -1)
                                 let font = CTFontCreateWithName("Times" as CFString, 350, &flip)
                                 let height = CTFontGetXHeight(font)
                                 var translate = CGAffineTransform.init(translationX: 0, y: -height + 15)
-                                
+
                                 var unichar1: UniChar = ("B" as NSString).character(at: 0)
                                 var glyph1: CGGlyph = 0
                                 CTFontGetGlyphsForCharacters(font, &unichar1, &glyph1, 1)
-                                
+
                                 var unichar2: UniChar = ("x" as NSString).character(at: 0)
                                 var glyph2: CGGlyph = 0
                                 CTFontGetGlyphsForCharacters(font, &unichar2, &glyph2, 1)
-                                
+
                                 assert(glyph1 != 0 && glyph2 != 0, "couldn't get glyphs")
-                                
+
                                 let cgPath1: CGPath = CTFontCreatePathForGlyph(font, glyph1, nil)!
                                 var path1 = Path(cgPath: cgPath1.copy(using: &translate)!)
-                                
+
                                 if let mouse = demoState.lastInputLocation {
-                                    
+
 //                                    let m2 = CGPoint(x: -21.19140625, y: 131.38671875)
 //                                    let me2 = CGPoint(x: 24.34375, y: 110.703125)
 //
 //                                    let me3 = CGPoint(x: -7.78515625, y: 161.7265625) // seems to cause an issue because intersections[5].t = 0.99999422905833845, clamping the t values when they are appropximately 1 or 0 seems to work (but fix not applied)
 //                                     let me4 = CGPoint(x: 22.41796875, y: 168.48046875) // caused an infinite loop or graphical glitches (increasing precision of boolean operation appears to resolve)
-                                    
+
                                     var translation = CGAffineTransform.init(translationX: mouse.x, y: mouse.y)
                                     let cgPath2: CGPath = CTFontCreatePathForGlyph(font, glyph2, &translation)!
                                     let path2 = Path(cgPath: cgPath2)
-                                    
+
 //                                    Draw.drawPath(context, path2)
 
 //                                    for intersection in path1.intersects(path: path2) {
 //                                        Draw.drawPoint(context, origin: intersection)
 //                                    }
-                                    
+
 //                                    var first: Vertex = augmentedGraph.v1
 //                                    var v = first
 //                                    repeat {
@@ -463,7 +455,7 @@ class Demos {
 //                                        Draw.drawPoint(context, origin: v.location)
 //                                        v = v.next
 //                                    } while v !== first
-                                    
+
                                     let subtracted = path1.intersect(path2) ?? path1
                                     Draw.drawPath(context, subtracted)
                                 }
@@ -471,16 +463,16 @@ class Demos {
     static let demo24 = Demo(title: "BVH",
                              quadraticControlPoints: [],
                              cubicControlPoints: [],
-                             drawFunction: {(context: CGContext, demoState: DemoState) in
-                       
+                             drawFunction: {(context: CGContext, _: DemoState) in
+
                                 func location(_ angle: CGFloat) -> CGPoint {
                                     return 200.0 * CGPoint(x: cos(angle), y: sin(angle))
                                 }
-                                
+
                                 let numPoints = 1000
-                                
+
                                 let radiansPerPoint = 2.0 * CGFloat.pi / CGFloat(numPoints)
-                                
+
                                 let startingAngle: CGFloat = 0
                                 let mutablePath = CGMutablePath()
                                 mutablePath.move(to: location(0.0) )
@@ -489,14 +481,12 @@ class Demos {
                                     mutablePath.addLine(to: location(angle))
                                 }
                                 mutablePath.closeSubpath()
-                                
+
                                 let path = Path(cgPath: mutablePath)
                                 for s in path.components {
                                     Draw.drawPathComponent(context, pathComponent: s, offset: CGPoint(x: 100.0, y: 100.0), includeBoundingVolumeHierarchy: true)
                                 }
 
-                                
-                                
     })
 
     static let all: [Demo] = [demo1, demo2, demo3, demo4, demo5, demo6, demo7, demo8, demo9, demo10, demo11, demo12, demo13, demo14, demo15, demo16, demo17, demo18, demo19, demo20, demo21, demo22, demo23, demo24]

--- a/BezierKit/MacDemos/Demos.swift
+++ b/BezierKit/MacDemos/Demos.swift
@@ -424,11 +424,8 @@ class Demos {
 
                                 if let mouse = demoState.lastInputLocation {
 
-//                                    let m2 = CGPoint(x: -21.19140625, y: 131.38671875)
-//                                    let me2 = CGPoint(x: 24.34375, y: 110.703125)
-//
-//                                    let me3 = CGPoint(x: -7.78515625, y: 161.7265625) // seems to cause an issue because intersections[5].t = 0.99999422905833845, clamping the t values when they are appropximately 1 or 0 seems to work (but fix not applied)
-//                                     let me4 = CGPoint(x: 22.41796875, y: 168.48046875) // caused an infinite loop or graphical glitches (increasing precision of boolean operation appears to resolve)
+                                    //let me3 = CGPoint(x: -7.78515625, y: 161.7265625) // seems to cause an issue (perhaps?) because intersections[5].t = 0.99999422905833845, clamping the t values when they are appropximately 1 or 0 seems to work (but fix not applied)
+                                     //let me4 = CGPoint(x: 22.41796875, y: 168.48046875) // caused an infinite loop or graphical glitches (increasing precision of boolean operation appears to resolve)
 
                                     var translation = CGAffineTransform.init(translationX: mouse.x, y: mouse.y)
                                     let cgPath2: CGPath = CTFontCreatePathForGlyph(font, glyph2, &translation)!

--- a/BezierKit/MacDemos/Draggable.swift
+++ b/BezierKit/MacDemos/Draggable.swift
@@ -16,12 +16,12 @@ protocol DraggableDelegate: class {
 }
 
 class Draggable {
-    
+
     private(set) public var location: CGPoint
     public weak var delegate: DraggableDelegate?
     private let callback: DraggableCallback
     public let radius: CGFloat
-    
+
     public init(initialLocation location: CGPoint, radius: CGFloat, callback: @escaping DraggableCallback) {
         self.location = location
         self.radius = radius
@@ -50,5 +50,5 @@ class Draggable {
         return CGRect( origin: CGPoint(x: self.location.x - r, y: self.location.y - r),
                        size: CGSize(width: r2, height: r2))
     }
-    
+
 }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To integrate BezierKit into your Xcode project using CocoaPods, add it to your t
 
 ```ruby
 target '<Your Target Name>' do
-    pod 'BezierKit', '>= 0.5.7'
+    pod 'BezierKit', '>= 0.5.8'
 end
 ```
 


### PR DESCRIPTION
- improves thread safety of `Path.cgPath` and other lazily computed properties
- adds swiftlint rules for code quality (though these are not yet enforced)
- improvements to vector boolean methods
- improvements to line / curve intersection

note: this release increases Mac and iOS deployment targets to MacOS 10.12 and iOS 10 respectively.