### PR TITLE
Hashable Path and PathComponent

### DIFF
--- a/BezierKit/BezierKitTests/PathComponentTests.swift
+++ b/BezierKit/BezierKitTests/PathComponentTests.swift
@@ -111,6 +111,18 @@ class PathComponentTests: XCTestCase {
         XCTAssertTrue(pathComponent1.isEqual(pathComponent2))
         XCTAssertFalse(pathComponent1.isEqual(pathComponent3))
     }
+    
+    func testHashing() {
+        // two paths that are equal
+        let l1 = LineSegment(p0: p1, p1: p2)
+        let q1 = QuadraticCurve(p0: p2, p1: p3, p2: p4)
+        let l2 = LineSegment(p0: p4, p1: p5)
+        let c1 = CubicCurve(p0: p5, p1: p6, p2: p7, p3: p8)
+        let pathComponent1 = PathComponent(curves: [l1, q1, l2, c1])
+        let pathComponent2 = PathComponent(curves: [l1, q1, l2, c1])
+                            
+        XCTAssert(pathComponent1.hash == pathComponent2.hash)
+    }
 
     func testIndexedPathComponentLocation() {
         let location1 = IndexedPathComponentLocation(elementIndex: 0, t: 0.5)

--- a/BezierKit/BezierKitTests/PathComponentTests.swift
+++ b/BezierKit/BezierKitTests/PathComponentTests.swift
@@ -113,7 +113,7 @@ class PathComponentTests: XCTestCase {
     }
     
     func testHashing() {
-        // two paths that are equal
+        // two PathComponents that are equal
         let l1 = LineSegment(p0: p1, p1: p2)
         let q1 = QuadraticCurve(p0: p2, p1: p3, p2: p4)
         let l2 = LineSegment(p0: p4, p1: p5)
@@ -122,6 +122,10 @@ class PathComponentTests: XCTestCase {
         let pathComponent2 = PathComponent(curves: [l1, q1, l2, c1])
                             
         XCTAssert(pathComponent1.hash == pathComponent2.hash)
+        
+        // PathComponent that is equal should be located in a set
+        let set = Set([pathComponent1])
+        XCTAssert(set.contains(pathComponent2))
     }
 
     func testIndexedPathComponentLocation() {

--- a/BezierKit/BezierKitTests/PathTests.swift
+++ b/BezierKit/BezierKitTests/PathTests.swift
@@ -305,6 +305,11 @@ class PathTests: XCTestCase {
         let path2 = Path(cgPath: CGPath(rect: rect, transform: nil))
         
         XCTAssert(path1.hash == path2.hash)
+        
+        // path that is equal should be located in a set
+        let path3 = path1.copy(using: CGAffineTransform.identity)
+        let set = Set([path1])
+        XCTAssert(set.contains(path3))
     }
 
     func testEncodeDecode() {

--- a/BezierKit/BezierKitTests/PathTests.swift
+++ b/BezierKit/BezierKitTests/PathTests.swift
@@ -297,6 +297,15 @@ class PathTests: XCTestCase {
         XCTAssertFalse(path1.isEqual(path2))
         XCTAssertTrue(path1.isEqual(path3))
     }
+    
+    func testHashing() {
+        // two paths that are equal
+        let rect = CGRect(origin: CGPoint(x: -1, y: -1), size: CGSize(width: 2, height: 2))
+        let path1 = Path(cgPath: CGPath(rect: rect, transform: nil))
+        let path2 = Path(cgPath: CGPath(rect: rect, transform: nil))
+        
+        XCTAssert(path1.hash == path2.hash)
+    }
 
     func testEncodeDecode() {
         let rect = CGRect(origin: CGPoint(x: -1, y: -1), size: CGSize(width: 2, height: 2))

--- a/BezierKit/Library/Path.swift
+++ b/BezierKit/Library/Path.swift
@@ -101,6 +101,14 @@ internal func windingCountImpliesContainment(_ count: Int, using rule: PathFillR
             BoundingBox(first: $0, second: $1.boundingBoxOfPath)
         }
     }()
+    
+    private lazy var _hash: Int = {
+        var hasher = Hasher()
+        for component in components {
+            hasher.combine(component)
+        }
+        return hasher.finalize()
+    }()
 
     @objc public let components: [PathComponent]
 
@@ -352,6 +360,13 @@ internal func windingCountImpliesContainment(_ count: Int, using rule: PathFillR
 @objc extension Path: Reversible {
     public func reversed() -> Self {
         return type(of: self).init(components: self.components.map { $0.reversed() })
+    }
+}
+
+extension Path {
+    public override var hash: Int {
+        // override is needed because NSObject hashing is independent of Swift's Hashable
+        return _hash
     }
 }
 

--- a/BezierKit/Library/Path.swift
+++ b/BezierKit/Library/Path.swift
@@ -102,13 +102,7 @@ internal func windingCountImpliesContainment(_ count: Int, using rule: PathFillR
         }
     }()
     
-    private lazy var _hash: Int = {
-        var hasher = Hasher()
-        for component in components {
-            hasher.combine(component)
-        }
-        return hasher.finalize()
-    }()
+    private var _hash: Int?
 
     @objc public let components: [PathComponent]
 
@@ -366,7 +360,16 @@ internal func windingCountImpliesContainment(_ count: Int, using rule: PathFillR
 extension Path {
     public override var hash: Int {
         // override is needed because NSObject hashing is independent of Swift's Hashable
-        return _hash
+        if let _hash = _hash { return _hash }
+        return lock.sync {
+            var hasher = Hasher()
+            for component in components {
+                hasher.combine(component)
+            }
+            let h = hasher.finalize()
+            _hash = h
+            return h
+        }
     }
 }
 

--- a/BezierKit/Library/PathComponent.swift
+++ b/BezierKit/Library/PathComponent.swift
@@ -26,6 +26,18 @@ import Foundation
     }
 
     private lazy var _bvh: BoundingBoxHierarchy = BoundingBoxHierarchy(boxes: (0..<self.numberOfElements).map { self.element(at: $0).boundingBox })
+    
+    private lazy var _hash: Int = {
+        var hasher = Hasher()
+        for order in orders {
+            hasher.combine(order)
+        }
+        for point in points {
+            hasher.combine(point.x)
+            hasher.combine(point.y)
+        }
+        return hasher.finalize()
+    }()
 
     private lazy var _boundingBoxOfPath: BoundingBox = {
         var boundingBoxOfPath = BoundingBox.empty
@@ -412,6 +424,11 @@ import Foundation
             return false
         }
         return self.orders == otherPathComponent.orders && self.points == otherPathComponent.points
+    }
+    
+    public override var hash: Int {
+        // override is needed because NSObject hashing is independent of Swift's Hashable
+        return _hash
     }
 
     // MARK: -

--- a/BezierKit/Library/PathComponent.swift
+++ b/BezierKit/Library/PathComponent.swift
@@ -27,17 +27,7 @@ import Foundation
 
     private lazy var _bvh: BoundingBoxHierarchy = BoundingBoxHierarchy(boxes: (0..<self.numberOfElements).map { self.element(at: $0).boundingBox })
     
-    private lazy var _hash: Int = {
-        var hasher = Hasher()
-        for order in orders {
-            hasher.combine(order)
-        }
-        for point in points {
-            hasher.combine(point.x)
-            hasher.combine(point.y)
-        }
-        return hasher.finalize()
-    }()
+    private var _hash: Int? = nil
 
     private lazy var _boundingBoxOfPath: BoundingBox = {
         var boundingBoxOfPath = BoundingBox.empty
@@ -428,7 +418,20 @@ import Foundation
     
     public override var hash: Int {
         // override is needed because NSObject hashing is independent of Swift's Hashable
-        return _hash
+        if let _hash = _hash { return _hash }
+        return lock.sync {
+            var hasher = Hasher()
+            for order in orders {
+                hasher.combine(order)
+            }
+            for point in points {
+                hasher.combine(point.x)
+                hasher.combine(point.y)
+            }
+            let h = hasher.finalize()
+            _hash = h
+            return h
+        }
     }
 
     // MARK: -


### PR DESCRIPTION
Fixes #47

## Overview
This PR overrides `NSObject`'s default memory address hash for `Path` and `PathComponent`. Paths that have the same components in the same order will always have the same hash value. Computing the hash can be expensive so the implementation uses a lazy variable to cache the result. One concern I had with this approach is if someone serializes the objects and restores them on a new program launch, the `Hasher` would not have the same seed, and the hash of a new equal path would be different from a decoded one. However, this cannot happen if the developer uses the public `init?(data: Data)` and `var data: Data` interface for paths. With that initializer, paths are decoded exclusively from the `PathComponent` orders and points data.