### PR TITLE
Fix for issue #84

### DIFF
--- a/BezierKit/BezierKitTests/Path+VectorBooleanTests.swift
+++ b/BezierKit/BezierKitTests/Path+VectorBooleanTests.swift
@@ -729,6 +729,30 @@ class PathVectorBooleanTests: XCTestCase {
         XCTAssertEqual(result.components.first?.numberOfElements, 7)
     }
 
+    func testCrossingsRemovedCoincidentPoints() {
+        // GitHub issue #84: crossingsRemoved gets confused by coincident points
+        // Two overlapping triangles where one has a zero-length degenerate segment at (100, 585).
+        // crossingsRemoved() should merge them into a single component, preserving the zero-length segment.
+        let comp0 = PathComponent(curves: [
+            LineSegment(p0: CGPoint(x: 100, y: 585), p1: CGPoint(x: 100, y: 585)),
+            LineSegment(p0: CGPoint(x: 100, y: 585), p1: CGPoint(x: 225, y: 585)),
+            LineSegment(p0: CGPoint(x: 225, y: 585), p1: CGPoint(x: 100, y: 680)),
+            LineSegment(p0: CGPoint(x: 100, y: 680), p1: CGPoint(x: 100, y: 585))
+        ] as [BezierCurve])
+        let comp1 = PathComponent(curves: [
+            LineSegment(p0: CGPoint(x: 260, y: 392), p1: CGPoint(x: 260, y: 585)),
+            LineSegment(p0: CGPoint(x: 260, y: 585), p1: CGPoint(x: 160, y: 680)),
+            LineSegment(p0: CGPoint(x: 160, y: 680), p1: CGPoint(x: 260, y: 392))
+        ] as [BezierCurve])
+        let path = Path(components: [comp0, comp1])
+        let result = path.crossingsRemoved()
+        XCTAssertEqual(result.components.count, 1)
+        let hasZeroLengthSegment = result.components[0].curves.contains {
+            $0.startingPoint == CGPoint(x: 100, y: 585) && $0.endingPoint == CGPoint(x: 100, y: 585)
+        }
+        XCTAssertTrue(hasZeroLengthSegment, "degenerate zero-length segment should be preserved in result")
+    }
+
     func testCrossingsRemovedRealWorldInfiniteLoop() {
 
         // in testing this data previously caused an infinite loop in AgumentedGraph.booleanOperation(_:)

--- a/BezierKit/Library/AugmentedGraph.swift
+++ b/BezierKit/Library/AugmentedGraph.swift
@@ -82,7 +82,12 @@ private class Edge {
     }
     func visitCoincidentEdges() {
         let component = self.component
-        let location = IndexedPathComponentLocation(elementIndex: 0, t: 0.5)
+        var location = IndexedPathComponentLocation(elementIndex: 0, t: 0.5)
+        for i in 0..<component.numberOfElements {
+            let loc = IndexedPathComponentLocation(elementIndex: i, t: 0.5)
+            let n = component.normal(at: loc)
+            if n.x.isFinite && n.y.isFinite && n != .zero { location = loc; break }
+        }
         let point = component.point(at: location)
         let normal = component.normal(at: location)
         let smallDistance: CGFloat = AugmentedGraph.smallDistance
@@ -234,9 +239,13 @@ private extension AugmentedGraph {
     }
     func classifyEdges(in graph: PathGraph, isForFirstPath: Bool) {
         func classifyEdge(_ edge: Edge) {
-            // TODO: we use a crummy point location
             let component = edge.component
-            let location = IndexedPathComponentLocation(elementIndex: 0, t: 0.5)
+            var location = IndexedPathComponentLocation(elementIndex: 0, t: 0.5)
+            for i in 0..<component.numberOfElements {
+                let loc = IndexedPathComponentLocation(elementIndex: i, t: 0.5)
+                let n = component.normal(at: loc)
+                if n.x.isFinite && n.y.isFinite && n != .zero { location = loc; break }
+            }
             let point = component.point(at: location)
             let normal = component.normal(at: location)
             let smallDistance: CGFloat = AugmentedGraph.smallDistance

--- a/BezierKit/Library/AugmentedGraph.swift
+++ b/BezierKit/Library/AugmentedGraph.swift
@@ -82,12 +82,7 @@ private class Edge {
     }
     func visitCoincidentEdges() {
         let component = self.component
-        var location = IndexedPathComponentLocation(elementIndex: 0, t: 0.5)
-        for i in 0..<component.numberOfElements {
-            let loc = IndexedPathComponentLocation(elementIndex: i, t: 0.5)
-            let n = component.normal(at: loc)
-            if n.x.isFinite && n.y.isFinite && n != .zero { location = loc; break }
-        }
+        let location = component.nonDegenerateTestLocation
         let point = component.point(at: location)
         let normal = component.normal(at: location)
         let smallDistance: CGFloat = AugmentedGraph.smallDistance
@@ -240,12 +235,7 @@ private extension AugmentedGraph {
     func classifyEdges(in graph: PathGraph, isForFirstPath: Bool) {
         func classifyEdge(_ edge: Edge) {
             let component = edge.component
-            var location = IndexedPathComponentLocation(elementIndex: 0, t: 0.5)
-            for i in 0..<component.numberOfElements {
-                let loc = IndexedPathComponentLocation(elementIndex: i, t: 0.5)
-                let n = component.normal(at: loc)
-                if n.x.isFinite && n.y.isFinite && n != .zero { location = loc; break }
-            }
+            let location = component.nonDegenerateTestLocation
             let point = component.point(at: location)
             let normal = component.normal(at: location)
             let smallDistance: CGFloat = AugmentedGraph.smallDistance
@@ -333,5 +323,16 @@ private extension AugmentedGraph {
         }
         points[points.count - 1] = points[0]
         return PathComponent(points: points, orders: orders)
+    }
+}
+
+private extension PathComponent {
+    var nonDegenerateTestLocation: IndexedPathComponentLocation {
+        for i in 0..<numberOfElements {
+            let loc = IndexedPathComponentLocation(elementIndex: i, t: 0.5)
+            let n = normal(at: loc)
+            if n.x.isFinite && n.y.isFinite && n != .zero { return loc }
+        }
+        return IndexedPathComponentLocation(elementIndex: 0, t: 0.5)
     }
 }


### PR DESCRIPTION
  Root cause: In AugmentedGraph.swift, both classifyEdge and visitCoincidentEdges unconditionally sampled the midpoint of element 0 of each edge's component to    
  obtain a test point and normal for inside/outside classification. When element 0 is a zero-length line segment (p0 == p1), its normal is (p1 -                   
  p0).perpendicular.normalize() = zero.perpendicular.normalize() = (0,0)/0 = (NaN, NaN). With a NaN normal, the two offset test points are identical (NaN          
  arithmetic), both sides give the same contains() result, and the edge is incorrectly classified as inSolution = false — causing the entire result to be empty.   
                                                                                                                                                                   
  Fix: Added a loop in both functions to find the first element with a finite, non-zero normal before sampling. If element 0 is degenerate, it skips forward to a  
  valid element. The zero-length segment itself remains part of the edge that is then correctly classified as inSolution = true, so it is preserved in the output.
                                                                                                                                                                   
  Test: Added testCrossingsRemovedCoincidentPoints using mbutterick's exact Case 1 data — two overlapping triangles where one has a zero-length segment at (100,   
  585). The test asserts the result is a single merged component and that the zero-length segment is preserved.
