### PR TITLE
Fix crash in outline when all curve control points are coincident

### DIFF
--- a/BezierKit/BezierKitTests/BezierCurveTests.swift
+++ b/BezierKit/BezierKitTests/BezierCurveTests.swift
@@ -149,7 +149,7 @@ class BezierCurveTests: XCTestCase {
     func testOutlineDistance() {
         // When only one distance value is given, the outline is generated at distance d on both the normal and anti-normal
         let lineSegment = BezierCurveTests.lineSegmentForOutlining
-        let outline: PathComponent = lineSegment.outline(distance: 1)
+        let outline: PathComponent = lineSegment.outline(distance: 1)!
         XCTAssertEqual(outline.numberOfElements, 4)
 
         let (o0, o1, o2, o3) = lineOffsets(lineSegment, 1, 1, 1, 1)
@@ -165,7 +165,7 @@ class BezierCurveTests: XCTestCase {
         let lineSegment = BezierCurveTests.lineSegmentForOutlining
         let distanceAlongNormal: CGFloat = 1
         let distanceOppositeNormal: CGFloat = 2
-        let outline: PathComponent = lineSegment.outline(distanceAlongNormal: distanceAlongNormal, distanceOppositeNormal: distanceOppositeNormal)
+        let outline: PathComponent = lineSegment.outline(distanceAlongNormal: distanceAlongNormal, distanceOppositeNormal: distanceOppositeNormal)!
         XCTAssertEqual(outline.numberOfElements, 4)
 
         let o0 = lineSegment.startingPoint + distanceAlongNormal * lineSegment.normal(at: 0)
@@ -183,7 +183,7 @@ class BezierCurveTests: XCTestCase {
         // this tests a special corner case of outlines where endpoint normals are parallel
 
         let q = QuadraticCurve(p0: CGPoint(x: 0.0, y: 0.0), p1: CGPoint(x: 5.0, y: 0.0), p2: CGPoint(x: 10.0, y: 0.0))
-        let outline: PathComponent = q.outline(distance: 1)
+        let outline: PathComponent = q.outline(distance: 1)!
 
         let expectedSegment1 = LineSegment(p0: CGPoint(x: 0, y: -1), p1: CGPoint(x: 0, y: 1))
         let expectedSegment2 = LineSegment(p0: CGPoint(x: 0, y: 1), p1: CGPoint(x: 10, y: 1))
@@ -311,6 +311,15 @@ class BezierCurveTests: XCTestCase {
         // check line segment case
         let lineSegment = CubicCurve(lineSegment: LineSegment(p0: CGPoint(x: 1, y: 2), p1: CGPoint(x: 3, y: 4)))
         XCTAssertFalse(curveSelfIntersects(lineSegment))
+    }
+
+    func testOutlineDegenerateAllPointsSame() {
+        // issue #96: outline crashes (index out of bounds) when all control points are the same
+        let p = CGPoint(x: 1, y: 1)
+        let cubic = CubicCurve(p0: p, p1: p, p2: p, p3: p)
+        XCTAssertNil(cubic.outline(distance: 1))
+        let quadratic = QuadraticCurve(p0: p, p1: p, p2: p)
+        XCTAssertNil(quadratic.outline(distance: 1))
     }
 
     func testCubicSelfIntersectionEdgeCase() {

--- a/BezierKit/Library/BezierCurve.swift
+++ b/BezierKit/Library/BezierCurve.swift
@@ -206,11 +206,11 @@ extension BezierCurve {
 
     // MARK: - outlines
 
-    public func outline(distance d1: CGFloat) -> PathComponent {
+    public func outline(distance d1: CGFloat) -> PathComponent? {
         return internalOutline(d1: d1, d2: d1)
     }
 
-    public func outline(distanceAlongNormal d1: CGFloat, distanceOppositeNormal d2: CGFloat) -> PathComponent {
+    public func outline(distanceAlongNormal d1: CGFloat, distanceOppositeNormal d2: CGFloat) -> PathComponent? {
         return internalOutline(d1: d1, d2: d2)
     }
 
@@ -225,11 +225,12 @@ extension BezierCurve {
         }
     }
 
-    private func internalOutline(d1: CGFloat, d2: CGFloat) -> PathComponent {
+    private func internalOutline(d1: CGFloat, d2: CGFloat) -> PathComponent? {
         let reduced = self.reduce()
         let length = reduced.count
         var forwardCurves: [BezierCurve] = reduced.compactMap { $0.curve.scale(distance: d1) }
         var backCurves: [BezierCurve] = reduced.compactMap { $0.curve.scale(distance: -d2) }
+        guard forwardCurves.isEmpty == false, backCurves.isEmpty == false else { return nil }
         ensureContinuous(&forwardCurves)
         ensureContinuous(&backCurves)
         // reverse the "return" outline
@@ -252,7 +253,7 @@ extension BezierCurve {
     }
 
     public func outlineShapes(distanceAlongNormal d1: CGFloat, distanceOppositeNormal d2: CGFloat, accuracy: CGFloat = BezierKit.defaultIntersectionAccuracy) -> [Shape] {
-        let outline = self.outline(distanceAlongNormal: d1, distanceOppositeNormal: d2)
+        guard let outline = self.outline(distanceAlongNormal: d1, distanceOppositeNormal: d2) else { return [] }
         var shapes: [Shape] = []
         let len = outline.numberOfElements
         for i in 1..<len/2 {

--- a/BezierKit/MacDemos/Demos.swift
+++ b/BezierKit/MacDemos/Demos.swift
@@ -310,11 +310,12 @@ class Demos {
                                 Draw.drawCurve(context, curve: curve)
                                 Draw.setColor(context, color: Draw.red)
                                 let doc = {(c: BezierCurve) in Draw.drawCurve(context, curve: c) }
-                                let outline = curve.outline(distance: 25)
-                                outline.curves.forEach(doc)
-                                Draw.setColor(context, color: Draw.transparentBlue)
-                                outline.offset(distance: 10)?.curves.forEach(doc)
-                                outline.offset(distance: -10)?.curves.forEach(doc)
+                                if let outline = curve.outline(distance: 25) {
+                                    outline.curves.forEach(doc)
+                                    Draw.setColor(context, color: Draw.transparentBlue)
+                                    outline.offset(distance: 10)?.curves.forEach(doc)
+                                    outline.offset(distance: -10)?.curves.forEach(doc)
+                                }
     })
 
     static let demo17 = Demo(title: "outlineShapes",


### PR DESCRIPTION
Fixes Issue #96 

When all control points of a curve are the same, scale(distance:) returns nil because the normals are NaN. This left forwardCurves empty in internalOutline, causing a fatal index-out-of-bounds on forwardCurves[0].

Change outline(distance:) and outline(distanceAlongNormal:distanceOppositeNormal:) to return PathComponent? and guard against empty scaled-curve arrays in internalOutline, consistent with the existing PathComponent.offset -> PathComponent? pattern.