### PR TITLE
Add split(at:) methods to PathComponent and Path, Fixes issue #20

### DIFF
--- a/BezierKit/BezierKitTests/PathComponentTests.swift
+++ b/BezierKit/BezierKitTests/PathComponentTests.swift
@@ -208,6 +208,30 @@ class PathComponentTests: XCTestCase {
         XCTAssertEqual(split6alt, expectedValue6)
     }
 
+    func testSplitAtLocations() {
+        // no locations → returns the original component unchanged
+        XCTAssertEqual(circlePathComponent.split(at: []), [circlePathComponent])
+
+        // one location → two pieces that reconstruct the original
+        let loc1 = IndexedPathComponentLocation(elementIndex: 1, t: 0.5)
+        let pieces1 = circlePathComponent.split(at: [loc1])
+        XCTAssertEqual(pieces1.count, 2)
+        XCTAssertEqual(pieces1[0], circlePathComponent.split(from: circlePathComponent.startingIndexedLocation, to: loc1))
+        XCTAssertEqual(pieces1[1], circlePathComponent.split(from: loc1, to: circlePathComponent.endingIndexedLocation))
+
+        // two locations in order → three pieces
+        let loc2 = IndexedPathComponentLocation(elementIndex: 2, t: 0.3)
+        let pieces2 = circlePathComponent.split(at: [loc1, loc2])
+        XCTAssertEqual(pieces2.count, 3)
+        XCTAssertEqual(pieces2[0], circlePathComponent.split(from: circlePathComponent.startingIndexedLocation, to: loc1))
+        XCTAssertEqual(pieces2[1], circlePathComponent.split(from: loc1, to: loc2))
+        XCTAssertEqual(pieces2[2], circlePathComponent.split(from: loc2, to: circlePathComponent.endingIndexedLocation))
+
+        // locations passed in reverse order are sorted automatically
+        let pieces2reversed = circlePathComponent.split(at: [loc2, loc1])
+        XCTAssertEqual(pieces2reversed, pieces2)
+    }
+
     func testEnumeratePoints() {
         func arrayByEnumerating(component: PathComponent, includeControlPoints: Bool) -> [CGPoint] {
             var points: [CGPoint] = []

--- a/BezierKit/BezierKitTests/PathTests.swift
+++ b/BezierKit/BezierKitTests/PathTests.swift
@@ -966,6 +966,36 @@ class PathTests: XCTestCase {
     }
     #endif
 
+    func testSplitAtLocation() {
+        // Build a two-segment open path: line (0,0)→(1,0) then (1,0)→(2,0)
+        let seg1 = LineSegment(p0: CGPoint(x: 0, y: 0), p1: CGPoint(x: 1, y: 0))
+        let seg2 = LineSegment(p0: CGPoint(x: 1, y: 0), p1: CGPoint(x: 2, y: 0))
+        let component = PathComponent(curves: [seg1, seg2])
+        let path = Path(components: [component])
+
+        // split at the midpoint of the first segment (elementIndex=0, t=0.5) → point (0.5, 0)
+        let location = IndexedPathLocation(componentIndex: 0, elementIndex: 0, t: 0.5)
+        let (first, second) = path.split(at: location)
+
+        XCTAssertEqual(first.components.count, 1)
+        XCTAssertEqual(second.components.count, 1)
+
+        // first path should run from (0,0) to (0.5,0) — one half-segment
+        XCTAssertEqual(first.components[0].startingPoint, CGPoint(x: 0, y: 0))
+        XCTAssertEqual(first.components[0].endingPoint,   CGPoint(x: 0.5, y: 0))
+
+        // second path should run from (0.5,0) to (2,0) — a half-segment + full second segment
+        XCTAssertEqual(second.components[0].startingPoint, CGPoint(x: 0.5, y: 0))
+        XCTAssertEqual(second.components[0].endingPoint,   CGPoint(x: 2,   y: 0))
+        XCTAssertEqual(second.components[0].numberOfElements, 2)
+
+        // split at the junction between the two segments (elementIndex=1, t=0) → point (1,0)
+        let junction = IndexedPathLocation(componentIndex: 0, elementIndex: 1, t: 0)
+        let (beforeJunction, afterJunction) = path.split(at: junction)
+        XCTAssertEqual(beforeJunction.components[0].endingPoint, CGPoint(x: 1, y: 0))
+        XCTAssertEqual(afterJunction.components[0].startingPoint, CGPoint(x: 1, y: 0))
+    }
+
     func testIndexedPathLocation() {
         let location1 = IndexedPathLocation(componentIndex: 0, elementIndex: 1, t: 0.5)
         let location2 = IndexedPathLocation(componentIndex: 0, elementIndex: 1, t: 1.0)

--- a/BezierKit/Library/Path.swift
+++ b/BezierKit/Library/Path.swift
@@ -315,6 +315,18 @@ open class Path: NSObject, @unchecked Sendable {
         return !self.intersects(other, accuracy: accuracy)
     }
 
+    /// Splits the path at `location`, returning two paths: everything before the location and everything from the location onward.
+    public func split(at location: IndexedPathLocation) -> (Path, Path) {
+        let componentIndex = location.componentIndex
+        let component = self.components[componentIndex]
+        let loc = location.locationInComponent
+        let before = component.split(from: component.startingIndexedLocation, to: loc)
+        let after = component.split(from: loc, to: component.endingIndexedLocation)
+        let firstPath = Path(components: Array(self.components[0..<componentIndex]) + [before])
+        let secondPath = Path(components: [after] + Array(self.components[(componentIndex + 1)...]))
+        return (firstPath, secondPath)
+    }
+
     public func offset(distance d: CGFloat) -> Path {
         return Path(components: self.components.compactMap {
             $0.offset(distance: d)

--- a/BezierKit/Library/PathComponent.swift
+++ b/BezierKit/Library/PathComponent.swift
@@ -583,6 +583,21 @@ open class PathComponent: NSObject, Reversible, Transformable, @unchecked Sendab
         return self.split(range: PathComponentRange(from: start, to: end))
     }
 
+    /// Splits the path component at each location in `locations`, returning the pieces in order from start to end.
+    /// The result contains `locations.count + 1` components.
+    public func split(at locations: [IndexedPathComponentLocation]) -> [PathComponent] {
+        guard !locations.isEmpty else { return [self] }
+        let sorted = locations.sorted()
+        var result: [PathComponent] = []
+        var previous = self.startingIndexedLocation
+        for location in sorted {
+            result.append(self.split(from: previous, to: location))
+            previous = location
+        }
+        result.append(self.split(from: previous, to: self.endingIndexedLocation))
+        return result
+    }
+
     open func reversed() -> Self {
         return type(of: self).init(points: self.points.reversed(), orders: self.orders.reversed())
     }


### PR DESCRIPTION
PathComponent gains split(at: [IndexedPathComponentLocation]) which splits a component at multiple locations and returns the pieces in order. Path gains split(at: IndexedPathLocation) which splits a path at a single location, returning a (before, after) tuple. Together these let callers split an open path at intersection points — the core request in issue #20.