### PR TITLE
emit closeSubpath for closed paths whose last element is cubic or quadratic (issue #97)

### DIFF
--- a/BezierKit/BezierKitTests/PathTests.swift
+++ b/BezierKit/BezierKitTests/PathTests.swift
@@ -917,6 +917,37 @@ class PathTests: XCTestCase {
         XCTAssertEqual(records, expectedRecords)
     }
 
+    func testApplyClosedCubicPath() {
+        // A closed PathComponent made entirely of cubics (e.g. a circle) must emit
+        // closeSubpath via apply/appendPath even though no line segment closes the path.
+        let circlePath = Path(cgPath: CGPath(ellipseIn: CGRect(x: -1, y: -1, width: 2, height: 2), transform: nil))
+        let circleComponent = circlePath.components[0]
+        XCTAssertTrue(circleComponent.isClosed)
+        XCTAssertTrue(circleComponent.orders.allSatisfy { $0 == 3 }, "circle should be all cubics")
+
+        var records: [CGPathElementRecord] = []
+        func clearAndApply(_ block: (_: UnsafeMutablePointer<[CGPathElementRecord]>) -> Void) {
+            records.removeAll()
+            withUnsafeMutablePointer(to: &records) { block($0) }
+        }
+
+        // apply must end with closeSubpath
+        clearAndApply { circleComponent.apply(info: $0, function: applierFunction) }
+        XCTAssertEqual(records.last?.type, .closeSubpath,
+                       "closed cubic-only PathComponent must emit closeSubpath via apply")
+
+        // appendPath must produce a CGPath that also ends with closeSubpath
+        let mutablePath = CGMutablePath()
+        circleComponent.appendPath(to: mutablePath)
+        clearAndApply { mutablePath.apply(info: $0, function: applierFunction) }
+        XCTAssertEqual(records.last?.type, .closeSubpath,
+                       "closed cubic-only PathComponent must emit closeSubpath via appendPath")
+
+        // round-trip through CGPath must preserve the closed structure
+        let roundTripped = Path(cgPath: mutablePath).components[0]
+        XCTAssertEqual(roundTripped, circleComponent)
+    }
+
     #endif
 
     func testBoundingBoxOfPath() {

--- a/BezierKit/Library/PathComponent.swift
+++ b/BezierKit/Library/PathComponent.swift
@@ -165,10 +165,15 @@ open class PathComponent: NSObject, Reversible, Transformable, @unchecked Sendab
             }
             var element = CGPathElement(type: type, points: points)
             function(info, &element)
+            if i == numberOfElements - 1, isClosed, order > 1 {
+                var closeElement = CGPathElement(type: .closeSubpath, points: points)
+                function(info, &closeElement)
+            }
         }
     }
 
     internal func appendPath(to mutablePath: CGMutablePath) {
+        let isClosed = self.isClosed
         enumerateOrdersAndPoints { i, order, points in
             switch order {
             case 0:
@@ -187,6 +192,9 @@ open class PathComponent: NSObject, Reversible, Transformable, @unchecked Sendab
                 assertionFailureBadCurveOrder(order)
                 return
             }
+        }
+        if isClosed, let lastOrder = orders.last, lastOrder > 1 {
+            mutablePath.closeSubpath()
         }
     }
 


### PR DESCRIPTION
Closes issue #97 

Previously, apply(info:function:) and appendPath(to:) only emitted a closeSubpath element when the last curve in a closed PathComponent was a line segment. Closed paths made entirely of cubics (e.g. circles) were silently left open in their CGPath representation, causing incorrect stroke rendering (caps instead of joins at the closure point) and a broken round-trip through CGPath.