### PR TITLE
Optimize split(from:to:) with explicit FMA via addingProduct

### DIFF
--- a/BezierKit/BezierKitTests/PerformanceTests.swift
+++ b/BezierKit/BezierKitTests/PerformanceTests.swift
@@ -159,7 +159,7 @@ class PerformanceTests: XCTestCase {
     }
 
     func testQuadraticCurveSplitFromToPerformance() {
-        let dataCount = 10000000
+        let dataCount = 40000000
         let curves = generateRandomQuadraticCurves(count: dataCount, reseed: 5)
         srand48(5)
         let params: [(CGFloat, CGFloat)] = (0..<dataCount).map { _ in
@@ -177,8 +177,7 @@ class PerformanceTests: XCTestCase {
     }
 
     func testCubicCurveSplitFromToPerformance() {
-        // -Onone ~0.019, -Os ~0.0005
-        let dataCount = 10000000
+        let dataCount = 20000000
         let curves = generateRandomCurves(count: dataCount, reseed: 4)
         srand48(4)
         let params: [(CGFloat, CGFloat)] = (0..<dataCount).map { _ in

--- a/BezierKit/BezierKitTests/PerformanceTests.swift
+++ b/BezierKit/BezierKitTests/PerformanceTests.swift
@@ -152,6 +152,50 @@ class PerformanceTests: XCTestCase {
         }
     }
 
+    func generateRandomQuadraticCurves(count: Int, reseed: Int? = nil) -> [QuadraticCurve] {
+        if let reseed = reseed { srand48(reseed) }
+        func rp() -> CGPoint { CGPoint(x: CGFloat(drand48()), y: CGFloat(drand48())) }
+        return (0..<count).map { _ in QuadraticCurve(p0: rp(), p1: rp(), p2: rp()) }
+    }
+
+    func testQuadraticCurveSplitFromToPerformance() {
+        let dataCount = 10000000
+        let curves = generateRandomQuadraticCurves(count: dataCount, reseed: 5)
+        srand48(5)
+        let params: [(CGFloat, CGFloat)] = (0..<dataCount).map { _ in
+            let a = CGFloat(drand48()), b = CGFloat(drand48())
+            return a < b ? (a, b) : (b, a)
+        }
+        self.measure {
+            var sink = CGPoint.zero
+            for i in 0..<dataCount {
+                let s = curves[i].split(from: params[i].0, to: params[i].1)
+                sink.x += s.p0.x
+            }
+            XCTAssertNotEqual(sink, CGPoint.zero)
+        }
+    }
+
+    func testCubicCurveSplitFromToPerformance() {
+        // -Onone ~0.019, -Os ~0.0005
+        let dataCount = 10000000
+        let curves = generateRandomCurves(count: dataCount, reseed: 4)
+        srand48(4)
+        let params: [(CGFloat, CGFloat)] = (0..<dataCount).map { _ in
+            let a = CGFloat(drand48())
+            let b = CGFloat(drand48())
+            return a < b ? (a, b) : (b, a)
+        }
+        self.measure {
+            var sink = CGPoint.zero
+            for i in 0..<dataCount {
+                let s = curves[i].split(from: params[i].0, to: params[i].1)
+                sink.x += s.p0.x
+            }
+            XCTAssertNotEqual(sink, CGPoint.zero)
+        }
+    }
+
     func testCubicCurveProjectPerformance() {
         let c = CubicCurve(p0: CGPoint(x: -1, y: -1),
                            p1: CGPoint(x: 3, y: 1),

--- a/BezierKit/BezierKitTests/PerformanceTests.swift
+++ b/BezierKit/BezierKitTests/PerformanceTests.swift
@@ -159,7 +159,7 @@ class PerformanceTests: XCTestCase {
     }
 
     func testQuadraticCurveSplitFromToPerformance() {
-        let dataCount = 40000000
+        let dataCount = 10000000
         let curves = generateRandomQuadraticCurves(count: dataCount, reseed: 5)
         srand48(5)
         let params: [(CGFloat, CGFloat)] = (0..<dataCount).map { _ in
@@ -177,7 +177,7 @@ class PerformanceTests: XCTestCase {
     }
 
     func testCubicCurveSplitFromToPerformance() {
-        let dataCount = 20000000
+        let dataCount = 10000000
         let curves = generateRandomCurves(count: dataCount, reseed: 4)
         srand48(4)
         let params: [(CGFloat, CGFloat)] = (0..<dataCount).map { _ in

--- a/BezierKit/Library/CubicCurve.swift
+++ b/BezierKit/Library/CubicCurve.swift
@@ -188,14 +188,28 @@ public struct CubicCurve: NonlinearBezierCurve, Equatable, Sendable {
         return temp1 + temp2 + temp3
     }
 
+    @inline(__always) internal func pointAndDerivative(at t: CGFloat) -> (point: CGPoint, derivative: CGPoint) {
+        let mt: CGFloat = 1.0 - t
+        let mt_2: CGFloat = mt * mt
+        let t_2: CGFloat = t * t
+        let dp0 = 3.0 * (p1 - p0)
+        let dp1 = 3.0 * (p2 - p1)
+        let dp2 = 3.0 * (p3 - p2)
+        let w0 = mt_2 * mt; let w1 = 3.0 * mt_2 * t; let w2 = 3.0 * mt * t_2; let w3 = t_2 * t
+        var ptx = w0 * p0.x; ptx = ptx.addingProduct(w1, p1.x); ptx = ptx.addingProduct(w2, p2.x); ptx = ptx.addingProduct(w3, p3.x)
+        var pty = w0 * p0.y; pty = pty.addingProduct(w1, p1.y); pty = pty.addingProduct(w2, p2.y); pty = pty.addingProduct(w3, p3.y)
+        let mt2t = 2.0 * mt * t
+        var dtx = mt_2 * dp0.x; dtx = dtx.addingProduct(mt2t, dp1.x); dtx = dtx.addingProduct(t_2, dp2.x)
+        var dty = mt_2 * dp0.y; dty = dty.addingProduct(mt2t, dp1.y); dty = dty.addingProduct(t_2, dp2.y)
+        return (CGPoint(x: ptx, y: pty), CGPoint(x: dtx, y: dty))
+    }
+
     public func split(from t1: CGFloat, to t2: CGFloat) -> CubicCurve {
         guard t1 != 0.0 || t2 != 1.0 else { return self }
         let k = (t2 - t1) / 3.0
-        let p0 = self.point(at: t1)
-        let p3 = self.point(at: t2)
-        let p1 = p0 + k * self.derivative(at: t1)
-        let p2 = p3 - k * self.derivative(at: t2)
-        return CubicCurve(p0: p0, p1: p1, p2: p2, p3: p3)
+        let (q0, qd0) = pointAndDerivative(at: t1)
+        let (q3, qd3) = pointAndDerivative(at: t2)
+        return CubicCurve(p0: q0, p1: q0 + k * qd0, p2: q3 - k * qd3, p3: q3)
     }
 
     public func split(at t: CGFloat) -> (left: CubicCurve, right: CubicCurve) {

--- a/BezierKit/Library/CubicCurve.swift
+++ b/BezierKit/Library/CubicCurve.swift
@@ -209,7 +209,9 @@ public struct CubicCurve: NonlinearBezierCurve, Equatable, Sendable {
         let k = (t2 - t1) / 3.0
         let (q0, qd0) = pointAndDerivative(at: t1)
         let (q3, qd3) = pointAndDerivative(at: t2)
-        return CubicCurve(p0: q0, p1: q0 + k * qd0, p2: q3 - k * qd3, p3: q3)
+        let p1 = CGPoint(x: q0.x.addingProduct(k, qd0.x), y: q0.y.addingProduct(k, qd0.y))
+        let p2 = CGPoint(x: q3.x.addingProduct(-k, qd3.x), y: q3.y.addingProduct(-k, qd3.y))
+        return CubicCurve(p0: q0, p1: p1, p2: p2, p3: q3)
     }
 
     public func split(at t: CGFloat) -> (left: CubicCurve, right: CubicCurve) {

--- a/BezierKit/Library/QuadraticCurve.swift
+++ b/BezierKit/Library/QuadraticCurve.swift
@@ -109,13 +109,25 @@ public struct QuadraticCurve: NonlinearBezierCurve, Equatable, Sendable {
         return a*p0 + b*p1
     }
 
+    @inline(__always) internal func pointAndDerivative(at t: CGFloat) -> (point: CGPoint, derivative: CGPoint) {
+        let mt: CGFloat = 1.0 - t
+        let dp0 = 2.0 * (p1 - p0)
+        let dp1 = 2.0 * (p2 - p1)
+        let mt_2 = mt * mt; let tmt2 = 2.0 * mt * t; let t_2 = t * t
+        var ptx = mt_2 * p0.x; ptx = ptx.addingProduct(tmt2, p1.x); ptx = ptx.addingProduct(t_2, p2.x)
+        var pty = mt_2 * p0.y; pty = pty.addingProduct(tmt2, p1.y); pty = pty.addingProduct(t_2, p2.y)
+        var dtx = mt * dp0.x; dtx = dtx.addingProduct(t, dp1.x)
+        var dty = mt * dp0.y; dty = dty.addingProduct(t, dp1.y)
+        return (CGPoint(x: ptx, y: pty), CGPoint(x: dtx, y: dty))
+    }
+
     public func split(from t1: CGFloat, to t2: CGFloat) -> QuadraticCurve {
         guard t1 != 0.0 || t2 != 1.0 else { return self }
         let k = (t2 - t1) / 2
-        let p0 = self.point(at: t1)
-        let p2 = self.point(at: t2)
-        let p1 = (p0 + p2) / 2 + k / 2 * (self.derivative(at: t1) - self.derivative(at: t2))
-        return QuadraticCurve(p0: p0, p1: p1, p2: p2)
+        let (q0, qd0) = pointAndDerivative(at: t1)
+        let (q2, qd2) = pointAndDerivative(at: t2)
+        let q1 = (q0 + q2) / 2 + k / 2 * (qd0 - qd2)
+        return QuadraticCurve(p0: q0, p1: q1, p2: q2)
     }
 
     public func split(at t: CGFloat) -> (left: QuadraticCurve, right: QuadraticCurve) {


### PR DESCRIPTION
  ## Summary
            
  - Refactored `CubicCurve` and `QuadraticCurve` to compute point and derivative
    together in a single `@inline(__always) pointAndDerivative(at:)` method,                                                                                                                                    
    eliminating redundant Bernstein weight computation when `split(from:to:)` calls
    it twice                                                                                                                                                                                                    
  - Used `addingProduct(_:_:)` throughout for explicit FMA — Swift's `-O` does not
    fuse `mul+add` into FMA (IEEE 754 compliance), but `addingProduct` maps directly
    to a single `fmadd` instruction                                                                                                                                                                             
  - Applied the same to the p1/p2 control point construction in `CubicCurve.split`,
    converting four `fmul+fadd/fsub` pairs into `fmadd`/`fmsub`                                                                                                                                                 
  - Added `testCubicCurveSplitFromToPerformance` and                                                                                                                                                            
    `testQuadraticCurveSplitFromToPerformance` to `PerformanceTests`
                                                                                                                                                                                                                
  **Result in generated assembly (-Os):**                
  - `CubicCurve.split`: 24 `fmadd`/`fmsub` instructions (was 0; previously 4                                                                                                                                    
    separate function calls with no cross-call inlining)                    
  - `QuadraticCurve.split`: 6 SIMD `fmla.2d` instructions — the compiler                                                                                                                                        
    auto-vectorized the scalar `addingProduct` chains into 2-wide SIMD FMA once
    `pointAndDerivative` was inlined                                                                                                                                                                            
