### PR TITLE
Replace CGAffineTransform translation with CGPoint subtraction in project()

### DIFF
--- a/BezierKit/BezierKitTests/Path+VectorBooleanTests.swift
+++ b/BezierKit/BezierKitTests/Path+VectorBooleanTests.swift
@@ -802,4 +802,5 @@ class PathVectorBooleanTests: XCTestCase {
 //    }
 
     #endif
+
 }

--- a/BezierKit/BezierKitTests/PolynomialTests.swift
+++ b/BezierKit/BezierKitTests/PolynomialTests.swift
@@ -97,11 +97,14 @@ class PolynomialTests: XCTestCase {
     #if !(arch(i386) || arch(arm) || arch(wasm32))
     func testDegree4RepeatedRoots() {
         // x^4 - 2x^2 + 1
+        // derivative 4x^3 - 4x should produce intervals of -2, -1, 0, 1, 2
         let polynomial = BernsteinPolynomial4(b0: 1, b1: 1, b2: 2.0 / 3.0, b3: 0, b4: 0)
         let roots = findDistinctRoots(of: polynomial, between: -2, and: 2)
         XCTAssertEqual(roots.count, 2)
         XCTAssertEqual(roots[0], -1, accuracy: accuracy)
-        XCTAssertEqual(roots[1], 1, accuracy: accuracy)
+        if roots.count > 1 {
+            XCTAssertEqual(roots[1], 1, accuracy: accuracy)
+        }
     }
     #endif
     func testDegree5() {
@@ -120,6 +123,40 @@ class PolynomialTests: XCTestCase {
         XCTAssertEqual(roots.count, 2)
         XCTAssertEqual(roots[0], 0.15977874432923783, accuracy: 1.0e-5)
         XCTAssertEqual(roots[1], 0.407811682610126, accuracy: 1.0e-5)
+    }
+
+    func testDegree5RealWorldIssue() {
+        // Newton iteration does not converge and may return a non-root without the residual check.
+        let polynomial = BernsteinPolynomial5(b0: -68686.64586343056,
+                                              b1: 102389.02112160496,
+                                              b2: -163207.59913132348,
+                                              b3: 177077.4933777841,
+                                              b4: -108411.70135107233,
+                                              b5: 57838.81668210728)
+        let roots = findDistinctRootsInUnitInterval(of: polynomial)
+        XCTAssertEqual(roots.count, 1)
+        XCTAssertEqual(roots[0], 0.44454, accuracy: 1.0e-5)
+    }
+
+    func testDegree4RootAtLeftEndpoint() {
+        // degree-elevation of 2t(1-2t): roots at t=0 and t=0.5
+        let polynomial = BernsteinPolynomial4(b0: 0, b1: 0.5, b2: 1.0 / 3.0, b3: -0.5, b4: -2)
+        let roots = findDistinctRootsInUnitInterval(of: polynomial)
+        XCTAssertEqual(roots.count, 2)
+        XCTAssertEqual(roots[0], 0.0, accuracy: accuracy)
+        XCTAssertEqual(roots[1], 0.5, accuracy: accuracy)
+    }
+
+    func testDegree4SpuriousRootIssue() {
+        // Newton's method in the no-sign-change branch could produce a spurious root just outside [0,1].
+        let polynomial = BernsteinPolynomial4(b0: -0.14644808172857054,
+                                              b1: -0.07322397770821555,
+                                              b2: -0.024407908361312264,
+                                              b3: 9.473515889812933e-08,
+                                              b4: 4.217515225946045e-12)
+        let roots = findDistinctRootsInUnitInterval(of: polynomial)
+        XCTAssertEqual(roots.count, 1)
+        XCTAssertEqual(roots[0], CGFloat(0.9999932), accuracy: 1.0e-5)
     }
 
     func testDegreeN() {

--- a/BezierKit/BezierKitTests/QuadraticCurveTests.swift
+++ b/BezierKit/BezierKitTests/QuadraticCurveTests.swift
@@ -238,8 +238,8 @@ class QuadraticCurveTests: XCTestCase {
                                        p2: CGPoint(x: 7, y: 0))
         let intersections = quadratic.intersections(with: quadraticButActuallyLinear, accuracy: epsilon)
         XCTAssertEqual(intersections.count, 1)
-        XCTAssertEqual(intersections[0].t1, 0.5)
-        XCTAssertEqual(intersections[0].t2, 0.75)
+        XCTAssertEqual(intersections[0].t1, 0.5, accuracy: epsilon)
+        XCTAssertEqual(intersections[0].t2, 0.75, accuracy: epsilon)
     }
 
     // MARK: -

--- a/BezierKit/BezierKitTests/QuadraticCurveTests.swift
+++ b/BezierKit/BezierKitTests/QuadraticCurveTests.swift
@@ -221,7 +221,7 @@ class QuadraticCurveTests: XCTestCase {
                                        p2: CGPoint(x: 2, y: 0))
         let intersections = quadratic.intersections(with: quadraticWithColinearControlPoints, accuracy: epsilon)
         XCTAssertEqual(intersections.count, 1)
-        XCTAssertEqual(intersections[0].t1, 0.75)
+        XCTAssertEqual(intersections[0].t1, 0.75, accuracy: 1e-14)
         XCTAssertEqual(intersections[0].t2, 0.13962, accuracy: 1.0e-5)
     }
 

--- a/BezierKit/BezierKitTests/UtilsTests.swift
+++ b/BezierKit/BezierKitTests/UtilsTests.swift
@@ -55,20 +55,28 @@ class UtilsTests: XCTestCase {
         XCTAssertEqual(filtered.first!, CGFloat(0.1499651773565319), accuracy: 1.0e-3)
     }
 
-//    func testDrootsCubicWorldIssue2() {
-//        // this data is actually very close to a quadratic. It may get the wrong
-//        // answer is if is recognized as a cubic
-//        let points: [CGFloat] = [
-//            0.0000010000090924222604,
-//            0.0000013261883395898622,
-//            -0.1484297874302456,
-//            -0.44529201466082213
-//        ]
-//        let r = drootsCubicTestHelper(points[0], points[1], points[2], points[3])
-//        let filtered = r.filter { $0 >= 0 && $0 <= 1 }
-//        XCTAssertEqual(filtered.count, 1)
-//        XCTAssertEqual(filtered.first!, CGFloat(0.0014849), accuracy: 1.0e-4)
-//    }
+    func testDrootsCubicWorldIssue2() {
+        // this data is very close to a quadratic; Cardano's formula lost precision here (issue #92)
+        let points: [CGFloat] = [
+            0.0000010000090924222604,
+            0.0000013261883395898622,
+            -0.1484297874302456,
+            -0.44529201466082213
+        ]
+        let r = drootsCubicTestHelper(points[0], points[1], points[2], points[3])
+        XCTAssertEqual(r.count, 1)
+        XCTAssertEqual(r[0], CGFloat(0.0014849), accuracy: 1.0e-4)
+    }
+
+    func testDrootsCubicWorldIssue4() {
+        // Cardano's formula returned ~0.9997828 instead of ~0.999858 (issue #92).
+        // The cubic coefficient is small relative to the control point magnitudes, causing
+        // catastrophic cancellation in the power-basis conversion.
+        let r = drootsCubicTestHelper(117.11706850363589, 39.0399142482629,
+                                      -2.3525217329734005e-06, -2.352663614146877e-06)
+        XCTAssertEqual(r.count, 1)
+        XCTAssertEqual(r[0], CGFloat(0.999858), accuracy: 1.0e-5)
+    }
 
     func testDrootsCubicWorldIssue3() {
         // this data causes issue #81 on GitHub

--- a/BezierKit/Library/BernsteinPolynomialN.swift
+++ b/BezierKit/Library/BernsteinPolynomialN.swift
@@ -14,7 +14,8 @@ struct BernsteinPolynomialN: BernsteinPolynomial {
     let coefficients: [CGFloat]
 
     func difference(a1: CGFloat, a2: CGFloat) -> BernsteinPolynomialN {
-        fatalError("unimplemented.")
+        let diffs = (0..<order).map { a1 * coefficients[$0] + a2 * coefficients[$0 + 1] }
+        return BernsteinPolynomialN(coefficients: diffs)
     }
 
     var order: Int { return coefficients.count - 1 }

--- a/BezierKit/Library/BezierCurve+Implicitization.swift
+++ b/BezierKit/Library/BezierCurve+Implicitization.swift
@@ -113,6 +113,58 @@ internal struct ImplicitPolynomial {
     }
 }
 
+// MARK: - Zero-allocation Bernstein arithmetic for the cubic specialization of ImplicitPolynomial.value
+
+private func bernsteinMul(
+    _ left: UnsafePointer<CGFloat>, _ m: Int,
+    _ right: UnsafePointer<CGFloat>, _ n: Int,
+    into result: UnsafeMutablePointer<CGFloat>
+) {
+    // Precompute the three binomial rows (m, n, m+n) once; max 10 elements each.
+    withUnsafeTemporaryAllocation(of: CGFloat.self, capacity: 30) { tmp in
+        let mRow = tmp.baseAddress!
+        let nRow = tmp.baseAddress! + 10
+        let mnRow = tmp.baseAddress! + 20
+        for i in 0 ... m { mRow[i] = Utils.binomialCoefficient(m, choose: i) }
+        for i in 0 ... n { nRow[i] = Utils.binomialCoefficient(n, choose: i) }
+        for i in 0 ... m + n { mnRow[i] = Utils.binomialCoefficient(m + n, choose: i) }
+        for k in 0 ... m + n {
+            let lo = max(k - n, 0)
+            let hi = min(m, k)
+            var s = CGFloat.zero
+            for i in lo ... hi {
+                s += mRow[i] * nRow[k - i] * left[i] * right[k - i]
+            }
+            result[k] = s / mnRow[k]
+        }
+    }
+}
+
+private func bernsteinElevate(
+    _ src: UnsafePointer<CGFloat>, _ d: Int, by e: Int,
+    into result: UnsafeMutablePointer<CGFloat>
+) {
+    // Precompute the three binomial rows (d, e, d+e) once; max 10 elements each.
+    withUnsafeTemporaryAllocation(of: CGFloat.self, capacity: 30) { tmp in
+        let dRow = tmp.baseAddress!
+        let eRow = tmp.baseAddress! + 10
+        let deRow = tmp.baseAddress! + 20
+        for i in 0 ... d { dRow[i] = Utils.binomialCoefficient(d, choose: i) }
+        for i in 0 ... e { eRow[i] = Utils.binomialCoefficient(e, choose: i) }
+        for i in 0 ... d + e { deRow[i] = Utils.binomialCoefficient(d + e, choose: i) }
+        for k in 0 ... d + e {
+            let lo = max(k - e, 0)
+            let hi = min(d, k)
+            var s = CGFloat.zero
+            for l in lo ... hi {
+                s += dRow[l] * eRow[k - l] * src[l]
+            }
+            result[k] = s / deRow[k]
+        }
+    }
+}
+
+
 private struct ImplicitLineProduct {
     var a20, a11, a10, a02, a01, a00: CGFloat
     static func * (left: ImplicitLine, right: ImplicitLineProduct) -> ImplicitPolynomial {

--- a/BezierKit/Library/BezierCurve+Intersection.swift
+++ b/BezierKit/Library/BezierCurve+Intersection.swift
@@ -119,6 +119,7 @@ internal func helperIntersectsCurveCurve<U, T>(_ curve1: Subcurve<U>, _ curve2: 
 
     // try intersecting using Bezier clipping (Sederberg & Nishita 1990)
     var clipIntersections: [Intersection] = []
+    clipIntersections.reserveCapacity(curve1.curve.order * curve2.curve.order)
     var clipIterations = 0
     if Utils.bezierClipping(curve1, curve2, &clipIntersections, accuracy, &clipIterations) {
         // Slow-convergence subdivisions can produce near-duplicate intersections when

--- a/BezierKit/Library/BezierCurve+Intersection.swift
+++ b/BezierKit/Library/BezierCurve+Intersection.swift
@@ -117,13 +117,24 @@ fileprivate extension BezierCurve {
 
 internal func helperIntersectsCurveCurve<U, T>(_ curve1: Subcurve<U>, _ curve2: Subcurve<T>, accuracy: CGFloat) -> [Intersection] where U: NonlinearBezierCurve, T: NonlinearBezierCurve {
 
-    // try intersecting using subdivision
-    let lb = curve1.curve.boundingBox
-    let rb = curve2.curve.boundingBox
-    var pairIntersections: [Intersection] = []
-    var subdivisionIterations = 0
-    if Utils.pairiteration(curve1, curve2, lb, rb, &pairIntersections, accuracy, &subdivisionIterations) {
-        return pairIntersections.sortedAndUniqued()
+    // try intersecting using Bezier clipping (Sederberg & Nishita 1990)
+    var clipIntersections: [Intersection] = []
+    var clipIterations = 0
+    if Utils.bezierClipping(curve1, curve2, &clipIntersections, accuracy, &clipIterations) {
+        // Slow-convergence subdivisions can produce near-duplicate intersections when
+        // the same crossing is found in both halves of a split. Remove spatially-close
+        // duplicates: keep only the first intersection whose curve1 point is further than
+        // `accuracy` from every previously kept one.
+        let sorted = clipIntersections.sorted()
+        var result: [Intersection] = []
+        for ix in sorted {
+            let p1 = curve1.curve.point(at: ix.t1)
+            let isDuplicate = result.contains(where: { distanceSquared(p1, curve1.curve.point(at: $0.t1)) < accuracy * accuracy })
+            if !isDuplicate {
+                result.append(ix)
+            }
+        }
+        return result
     }
 
     // subdivision failed, check if the curves are coincident

--- a/BezierKit/Library/BezierCurve.swift
+++ b/BezierKit/Library/BezierCurve.swift
@@ -308,7 +308,8 @@ public protocol BezierCurve: BoundingBoxProtocol, Transformable, Reversible, Sen
 }
 
 internal protocol NonlinearBezierCurve: BezierCurve, ComponentPolynomials, Implicitizeable {
-    // intentionally empty, just declare conformance if you're not a line
+    // Point-by-index access without heap allocation — used by the bezier-clipping hot path.
+    func withPointsDo<R>(_ body: (Int, (Int) -> CGPoint) -> R) -> R
 }
 
 public protocol Flatness: BezierCurve {

--- a/BezierKit/Library/BezierCurve.swift
+++ b/BezierKit/Library/BezierCurve.swift
@@ -312,6 +312,24 @@ internal protocol NonlinearBezierCurve: BezierCurve, ComponentPolynomials, Impli
     func withPointsDo<R>(_ body: (Int, (Int) -> CGPoint) -> R) -> R
 }
 
+internal extension NonlinearBezierCurve {
+    // Axis-aligned bounding box of the control polygon — always an outer bound of the true
+    // curve bounding box (Bézier curves lie within the convex hull of their control points).
+    // Cheaper than `boundingBox` because it needs no droots/sqrt computation.
+    var controlPolygonBounds: BoundingBox {
+        return withPointsDo { n, pt in
+            var minX = CGFloat.infinity; var maxX = -CGFloat.infinity
+            var minY = CGFloat.infinity; var maxY = -CGFloat.infinity
+            for i in 0..<n {
+                let p = pt(i)
+                if p.x < minX { minX = p.x }; if p.x > maxX { maxX = p.x }
+                if p.y < minY { minY = p.y }; if p.y > maxY { maxY = p.y }
+            }
+            return BoundingBox(min: CGPoint(x: minX, y: minY), max: CGPoint(x: maxX, y: maxY))
+        }
+    }
+}
+
 public protocol Flatness: BezierCurve {
     // the flatness of a curve is defined as the square of the maximum distance it is from a line connecting its endpoints https://jeremykun.com/2013/05/11/bezier-curves-and-picasso/
     var flatnessSquared: CGFloat { get }

--- a/BezierKit/Library/CubicCurve.swift
+++ b/BezierKit/Library/CubicCurve.swift
@@ -23,6 +23,12 @@ public struct CubicCurve: NonlinearBezierCurve, Equatable, Sendable {
         return [p0, p1, p2, p3]
     }
 
+    internal func withPointsDo<R>(_ body: (Int, (Int) -> CGPoint) -> R) -> R {
+        return body(4) { i in
+            switch i { case 0: return p0; case 1: return p1; case 2: return p2; default: return p3 }
+        }
+    }
+
     public var order: Int {
         return 3
     }

--- a/BezierKit/Library/CubicCurve.swift
+++ b/BezierKit/Library/CubicCurve.swift
@@ -228,7 +228,7 @@ public struct CubicCurve: NonlinearBezierCurve, Equatable, Sendable {
         func mul(_ a: CGPoint, _ b: CGPoint) -> CGPoint {
             return CGPoint(x: a.x * b.x, y: a.y * b.y)
         }
-        let c = self.copy(using: CGAffineTransform(translationX: -point.x, y: -point.y))
+        let c = CubicCurve(p0: p0 - point, p1: p1 - point, p2: p2 - point, p3: p3 - point)
         let q = QuadraticCurve(p0: self.p1 - self.p0, p1: self.p2 - self.p1, p2: self.p3 - self.p2)
         // p0, p1, p2, p3 form the control points of a Cubic Bezier Curve formed
         // by multiplying the polynomials q and l

--- a/BezierKit/Library/Polynomial.swift
+++ b/BezierKit/Library/Polynomial.swift
@@ -75,6 +75,41 @@ extension BernsteinPolynomial3: AnalyticalRoots {
     }
 }
 
+internal protocol AnalyticalRootsCallback {
+    func forEachDistinctRoot(between start: CGFloat, and end: CGFloat, _ callback: (CGFloat) -> Void)
+}
+
+extension BernsteinPolynomial0: AnalyticalRootsCallback {
+    func forEachDistinctRoot(between start: CGFloat, and end: CGFloat, _ callback: (CGFloat) -> Void) {}
+}
+
+extension BernsteinPolynomial1: AnalyticalRootsCallback {
+    func forEachDistinctRoot(between start: CGFloat, and end: CGFloat, _ callback: (CGFloat) -> Void) {
+        Utils.droots(self.b0, self.b1) {
+            guard $0 >= start, $0 <= end else { return }
+            callback($0)
+        }
+    }
+}
+
+extension BernsteinPolynomial2: AnalyticalRootsCallback {
+    func forEachDistinctRoot(between start: CGFloat, and end: CGFloat, _ callback: (CGFloat) -> Void) {
+        Utils.droots(self.b0, self.b1, self.b2) {
+            guard $0 >= start, $0 <= end else { return }
+            callback($0)
+        }
+    }
+}
+
+extension BernsteinPolynomial3: AnalyticalRootsCallback {
+    func forEachDistinctRoot(between start: CGFloat, and end: CGFloat, _ callback: (CGFloat) -> Void) {
+        Utils.droots(self.b0, self.b1, self.b2, self.b3) {
+            guard $0 >= start, $0 <= end else { return }
+            callback($0)
+        }
+    }
+}
+
 public extension BernsteinPolynomial {
     func value(at x: CGFloat) -> CGFloat {
         let oneMinusX = 1.0 - x
@@ -459,57 +494,15 @@ internal func findDistinctRootsCallback<P: BernsteinPolynomial>(
 
 
 public func findDistinctRootsInUnitInterval<P: BernsteinPolynomial>(of polynomial: P) -> [CGFloat] {
-    return findDistinctRoots(of: polynomial, between: 0, and: 1)
+    var result: [CGFloat] = []
+    findDistinctRootsCallback(of: polynomial, between: 0, and: 1) { result.append($0) }
+    return result
 }
 
 internal func findDistinctRoots<P: BernsteinPolynomial>(of polynomial: P, between start: CGFloat, and end: CGFloat) -> [CGFloat] {
-    assert(start < end)
-    if let analytical = polynomial as? AnalyticalRoots {
-        return analytical.distinctAnalyticalRoots(between: start, and: end)
-    }
-    let derivative = polynomial.derivative
-    let criticalPoints: [CGFloat] = findDistinctRoots(of: derivative, between: start, and: end)
-    let intervals: [CGFloat] = [start] + criticalPoints + [end]
-    var lastFoundRoot: CGFloat?
-    let roots = (0..<intervals.count-1).compactMap { (i: Int) -> CGFloat? in
-        let start   = intervals[i]
-        let end     = intervals[i+1]
-        let fStart  = polynomial.value(at: start)
-        let fEnd    = polynomial.value(at: end)
-        let root: CGFloat
-        if fStart * fEnd < 0 {
-            // TODO: if a critical point is a root we take this
-            // codepath due to roundoff and  converge only linearly to one end of interval
-            let guess = (start + end) / 2
-            let newtonRoot = newton(polynomial: polynomial, derivative: derivative, guess: guess)
-            if start < newtonRoot, newtonRoot < end {
-                root = newtonRoot
-            } else {
-                // newton's method failed / converged to the wrong root!
-                // rare, but can happen roughly 5% of the time
-                // see unit test: `testDegree4RealWorldIssue`
-                root = findRootBisection(of: polynomial, start: start, end: end)
-            }
-        } else {
-            let guess = end
-            let value = newton(polynomial: polynomial, derivative: derivative, guess: guess)
-            guard Swift.abs(value - guess) < 1.0e-5 else {
-                return nil // did not converge near guess
-            }
-            guard Swift.abs(polynomial.value(at: value)) < 1.0e-10 else {
-                return nil // not actually a root
-            }
-            root = value
-        }
-        if let lastFoundRoot = lastFoundRoot {
-            guard lastFoundRoot + 1.0e-5 < root else {
-                return nil // ensures roots are unique and ordered
-            }
-        }
-        lastFoundRoot = root
-        return root
-    }
-    return roots
+    var result: [CGFloat] = []
+    findDistinctRootsCallback(of: polynomial, between: start, and: end) { result.append($0) }
+    return result
 }
 
 // internal func findRoots<P: BernsteinPolynomial>(of polynomial: P, between start: CGFloat, and end: CGFloat) -> [CGFloat] {

--- a/BezierKit/Library/Polynomial.swift
+++ b/BezierKit/Library/Polynomial.swift
@@ -288,6 +288,14 @@ public struct BernsteinPolynomial4: BernsteinPolynomial, Sendable {
                            b2: a1 * b2 + a2 * b3,
                            b3: a1 * b3 + a2 * b4)
     }
+    public func value(at x: CGFloat) -> CGFloat {
+        let s = 1 - x, t = x
+        let c10 = s * b0 + t * b1; let c11 = s * b1 + t * b2
+        let c12 = s * b2 + t * b3; let c13 = s * b3 + t * b4
+        let c20 = s * c10 + t * c11; let c21 = s * c11 + t * c12; let c22 = s * c12 + t * c13
+        let c30 = s * c20 + t * c21; let c31 = s * c21 + t * c22
+        return s * c30 + t * c31
+    }
     public var order: Int { return 4 }
 }
 
@@ -336,6 +344,16 @@ public struct BernsteinPolynomial5: BernsteinPolynomial, Sendable {
                            b3: a1 * b3 + a2 * b4,
                            b4: a1 * b4 + a2 * b5)
     }
+    public func value(at x: CGFloat) -> CGFloat {
+        let s = 1 - x, t = x
+        let c10 = s * b0 + t * b1; let c11 = s * b1 + t * b2
+        let c12 = s * b2 + t * b3; let c13 = s * b3 + t * b4; let c14 = s * b4 + t * b5
+        let c20 = s * c10 + t * c11; let c21 = s * c11 + t * c12
+        let c22 = s * c12 + t * c13; let c23 = s * c13 + t * c14
+        let c30 = s * c20 + t * c21; let c31 = s * c21 + t * c22; let c32 = s * c22 + t * c23
+        let c40 = s * c30 + t * c31; let c41 = s * c31 + t * c32
+        return s * c40 + t * c41
+    }
     public var order: Int { return 5 }
 }
 
@@ -380,6 +398,65 @@ private func findRootBisection<P: BernsteinPolynomial>(of polynomial: P, start: 
     }
     return guess
 }
+
+// Zero-allocation root finder. Calls `callback` for each root in sorted order.
+// For degree ≤ 3, delegates to Utils.droots (analytical). For higher degrees,
+// finds critical points of the derivative recursively and searches each interval.
+// Intervals are stored in a withUnsafeTemporaryAllocation buffer (stack for small sizes).
+// Capacity is 6: BernsteinPolynomial5 is the highest-order type defined in this library,
+// and a degree-5 polynomial needs at most [start] + 4 critical points + [end] = 6 slots.
+// A compile-time constant lets the compiler stack-allocate the buffer without a dynamic alloca.
+internal func findDistinctRootsCallback<P: BernsteinPolynomial>(
+    of polynomial: P,
+    between start: CGFloat, and end: CGFloat,
+    _ callback: (CGFloat) -> Void
+) {
+    if let analytical = polynomial as? AnalyticalRootsCallback {
+        analytical.forEachDistinctRoot(between: start, and: end, callback)
+        return
+    }
+    let derivative = polynomial.derivative
+    withUnsafeTemporaryAllocation(of: CGFloat.self, capacity: 6) { buffer in
+        var count = 0
+        buffer[count] = start; count += 1
+        findDistinctRootsCallback(of: derivative, between: start, and: end) { criticalPoint in
+            buffer[count] = criticalPoint; count += 1
+        }
+        buffer[count] = end; count += 1
+        var lastFoundRoot: CGFloat?
+        for i in 0..<count - 1 {
+            let iStart = buffer[i]
+            let iEnd   = buffer[i + 1]
+            let fStart = polynomial.value(at: iStart)
+            let fEnd   = polynomial.value(at: iEnd)
+            let absFStart = Swift.abs(fStart)
+            let absFEnd = Swift.abs(fEnd)
+            let scale = Swift.max(absFStart, absFEnd)
+            let residualToConsiderRoot = scale * CGFloat.ulpOfOne.squareRoot()
+            let root: CGFloat
+            if fStart * fEnd < 0 {
+                let guess = (iStart + iEnd) / 2
+                let newtonRoot = newton(polynomial: polynomial, derivative: derivative, guess: guess)
+                if iStart < newtonRoot, newtonRoot < iEnd,
+                   Swift.abs(polynomial.value(at: newtonRoot)) <= residualToConsiderRoot {
+                    root = newtonRoot
+                } else {
+                    root = findRootBisection(of: polynomial, start: iStart, end: iEnd)
+                }
+            } else if absFStart <= residualToConsiderRoot, absFEnd >= residualToConsiderRoot {
+                root = iStart
+            } else if absFStart > residualToConsiderRoot, absFEnd <= residualToConsiderRoot {
+                root = iEnd
+            } else {
+                continue
+            }
+            if let lastFoundRoot, lastFoundRoot + 1.0e-5 >= root { continue }
+            lastFoundRoot = root
+            callback(root)
+        }
+    }
+}
+
 
 public func findDistinctRootsInUnitInterval<P: BernsteinPolynomial>(of polynomial: P) -> [CGFloat] {
     return findDistinctRoots(of: polynomial, between: 0, and: 1)

--- a/BezierKit/Library/QuadraticCurve.swift
+++ b/BezierKit/Library/QuadraticCurve.swift
@@ -56,6 +56,12 @@ public struct QuadraticCurve: NonlinearBezierCurve, Equatable, Sendable {
         return [p0, p1, p2]
     }
 
+    internal func withPointsDo<R>(_ body: (Int, (Int) -> CGPoint) -> R) -> R {
+        return body(3) { i in
+            switch i { case 0: return p0; case 1: return p1; default: return p2 }
+        }
+    }
+
     public var startingPoint: CGPoint {
         get {
             return p0

--- a/BezierKit/Library/QuadraticCurve.swift
+++ b/BezierKit/Library/QuadraticCurve.swift
@@ -143,7 +143,7 @@ public struct QuadraticCurve: NonlinearBezierCurve, Equatable, Sendable {
         func multiplyCoordinates(_ a: CGPoint, _ b: CGPoint) -> CGPoint {
             return CGPoint(x: a.x * b.x, y: a.y * b.y)
         }
-        let q = self.copy(using: CGAffineTransform(translationX: -point.x, y: -point.y))
+        let q = QuadraticCurve(p0: p0 - point, p1: p1 - point, p2: p2 - point)
         // p0, p1, p2, p3 form the control points of a cubic Bezier curve
         // created by multiplying the curve with its derivative
         let qd0 = q.p1 - q.p0

--- a/BezierKit/Library/RootFinding.swift
+++ b/BezierKit/Library/RootFinding.swift
@@ -24,29 +24,143 @@ struct RootFindingConfiguration {
 }
 
 extension BernsteinPolynomialN {
+
+    /// Calls `callback` for each unique, ordered real root in `[0, 1]`.
+    /// Roots are emitted in ascending order with exact duplicates suppressed inline.
+    /// Zero-allocation beyond the arena (which is heap-allocated when count is a runtime value).
+    func forEachDistinctRootInUnitInterval(configuration: RootFindingConfiguration = .default, _ callback: (CGFloat) -> Void) {
+        guard coefficients.contains(where: { $0 != .zero }) else { return }
+        let count = coefficients.count
+        let maxDepth = 48
+        coefficients.withUnsafeBufferPointer { inputPtr in
+            withUnsafeTemporaryAllocation(of: CGFloat.self, capacity: maxDepth * 4 * count) { arenaPtr in
+                // Wrap callback with inline deduplication so rootsCore stays at 8 parameters.
+                // lastRoot is captured by reference across all recursive rootsCore calls.
+                var lastRoot = CGFloat.infinity
+                BernsteinPolynomialN.rootsCore(
+                    coefficients: inputPtr,
+                    count: count,
+                    start: 0, end: 1,
+                    configuration: configuration,
+                    arena: arenaPtr,
+                    depth: 0,
+                    callback: {
+                        guard $0 != lastRoot else { return }
+                        lastRoot = $0
+                        callback($0)
+                    }
+                )
+            }
+        }
+    }
+
     /// Returns the unique, ordered real roots of the curve that fall within the unit interval `0 <= t <= 1`
     /// the roots are unique and ordered so that for  `i < j` they satisfy `root[i] < root[j]`
     /// - Returns: the array of roots
     func distinctRealRootsInUnitInterval(configuration: RootFindingConfiguration = .default) -> [CGFloat] {
-        guard coefficients.contains(where: { $0 != .zero }) else { return [] }
-        let result = BernsteinPolynomialN.rootsOfCurveMappedToRange(self, start: 0, end: 1, configuration: configuration)
-        guard result.isEmpty == false else { return [] }
-        assert(result == result.sorted())
-        // eliminate non-unique roots by comparing against neighbors
-        return result.indices.compactMap { i in
-            guard i == 0 || result[i] != result[i - 1] else { return nil }
-            return result[i]
+        var results: [CGFloat] = []
+        forEachDistinctRootInUnitInterval(configuration: configuration) { results.append($0) }
+        return results
+    }
+
+    // In-place de Casteljau split into pre-allocated left/right/scratch buffers.
+    private static func deCasteljauSplit(
+        input: UnsafeBufferPointer<CGFloat>,
+        count: Int,
+        at t: CGFloat,
+        left: UnsafeMutableBufferPointer<CGFloat>,
+        right: UnsafeMutableBufferPointer<CGFloat>,
+        scratch: UnsafeMutableBufferPointer<CGFloat>
+    ) {
+        let n = count - 1
+        for i in 0..<count { scratch[i] = input[i] }
+        left[0] = scratch[0]
+        right[n] = scratch[n]
+        for j in 1...n {
+            for i in 0...(n - j) {
+                scratch[i] = Utils.linearInterpolate(scratch[i], scratch[i + 1], t)
+            }
+            left[j] = scratch[0]
+            right[n - j] = scratch[n - j]
         }
     }
-    private static func rootsOfCurveMappedToRange(_ curve: BernsteinPolynomialN, start rangeStart: CGFloat, end rangeEnd: CGFloat, configuration: RootFindingConfiguration) -> [CGFloat] {
-        let n = curve.order
-        // find the range where the convex hull of `curve2D` intersects the x-Axis
+
+    // Converts Bernstein control points to power basis using iterative forward differences.
+    // a[m] = C(n,m) * Δ^m b_0, so p(t) = Σ a[m] * t^m.
+    private static func bernsteinToPowerBasis(_ coefficients: UnsafeBufferPointer<CGFloat>, count: Int) -> [Double] {
+        let n = count - 1
+        var diffs = (0..<count).map { Double(coefficients[$0]) }
+        var result = [Double](repeating: 0, count: count)
+        for m in 0...n {
+            result[m] = Double(Utils.binomialCoefficient(n, choose: m)) * diffs[0]
+            for k in 0..<(n - m) { diffs[k] = diffs[k + 1] - diffs[k] }
+        }
+        return result
+    }
+
+    private static func horner(_ c: [Double], at t: Double) -> Double {
+        var v = c[c.count - 1]
+        for i in stride(from: c.count - 2, through: 0, by: -1) { v = v * t + c[i] }
+        return v
+    }
+
+    // Arena layout per depth level (base = depth * 4 * count):
+    //   slotA = base + 0*count  (scratch / temp)
+    //   slotB = base + 1*count  (left or result)
+    //   slotC = base + 2*count  (right or intermediate)
+    //   slotD = base + 3*count  (secondary right, discarded)
+    // Children at depth+1 write to (depth+1)*4*count onward, never touching this level's slots.
+    private static func rootsCore(
+        coefficients: UnsafeBufferPointer<CGFloat>,
+        count: Int,
+        start rangeStart: CGFloat,
+        end rangeEnd: CGFloat,
+        configuration: RootFindingConfiguration,
+        arena: UnsafeMutableBufferPointer<CGFloat>,
+        depth: Int,
+        callback: (CGFloat) -> Void
+    ) {
+        let n = count - 1
+
+        // Descartes isolation: once a sub-interval has exactly one sign change the root
+        // is isolated. Switch to bisection on the power basis (O(n) Horner evals) instead
+        // of continuing Bézier clipping subdivision.
+        var coeffScale = 0.0
+        for i in 0..<count { coeffScale = Swift.max(coeffScale, Swift.abs(Double(coefficients[i]))) }
+        let signThreshold = coeffScale * 1e-10
+        var lastSign = 0
+        var signChanges = 0
+        for i in 0..<count {
+            let c = Double(coefficients[i])
+            guard Swift.abs(c) > signThreshold else { continue }
+            let s = c > 0 ? 1 : -1
+            if lastSign != 0, s != lastSign { signChanges += 1 }
+            lastSign = s
+        }
+        if signChanges == 1 {
+            let fLo = Double(coefficients[0])
+            let fHi = Double(coefficients[count - 1])
+            if fLo * fHi < 0 {
+                let pow = bernsteinToPowerBasis(coefficients, count: count)
+                var lo = 0.0, hi = 1.0, fL = fLo, fH = fHi
+                let threshold = Double(configuration.errorThreshold) / Double(rangeEnd - rangeStart)
+                while hi - lo > threshold {
+                    let mid = 0.5 * (lo + hi)
+                    let fMid = horner(pow, at: mid)
+                    if fMid == 0 { lo = mid; hi = mid; break }
+                    if (fL > 0) == (fMid > 0) { lo = mid; fL = fMid } else { hi = mid; fH = fMid }
+                }
+                callback(Utils.linearInterpolate(rangeStart, rangeEnd, CGFloat(0.5 * (lo + hi))))
+                return
+            }
+        }
+
         var lowerBound = CGFloat.infinity
         var upperBound = -CGFloat.infinity
         for i in 0..<n {
             for j in i+1...n {
-                let p1 = CGPoint(x: CGFloat(i) / CGFloat(n), y: curve.coefficients[i])
-                let p2 = CGPoint(x: CGFloat(j) / CGFloat(n), y: curve.coefficients[j])
+                let p1 = CGPoint(x: CGFloat(i) / CGFloat(n), y: coefficients[i])
+                let p2 = CGPoint(x: CGFloat(j) / CGFloat(n), y: coefficients[j])
                 guard p1.y != 0 || p2.y != 0 else {
                     assert(p2.x >= p1.x)
                     if p1.x < lowerBound { lowerBound = p1.x }
@@ -61,45 +175,64 @@ extension BernsteinPolynomialN {
                 }
             }
         }
-        // if the range is empty then convex hull doesn't intersect x-Axis, so we're done.
-        guard lowerBound.isFinite, upperBound.isFinite else { return [] }
-        // if the range is small enough that it's within the accuracy threshold
-        // we've narrowed it down to a root and we're done
+        guard lowerBound.isFinite, upperBound.isFinite else { return }
         let nextRangeStart = Utils.linearInterpolate(rangeStart, rangeEnd, lowerBound)
         let nextRangeEnd = Utils.linearInterpolate(rangeStart, rangeEnd, upperBound)
         guard nextRangeEnd - nextRangeStart > configuration.errorThreshold else {
-            let nextRangeMid = Utils.linearInterpolate(nextRangeStart, nextRangeEnd, 0.5)
-            return [nextRangeMid]
+            callback(Utils.linearInterpolate(nextRangeStart, nextRangeEnd, 0.5))
+            return
         }
-        // if the range where the convex hull intersects the x-Axis is too large
-        // we aren't converging quickly, perhaps due to multiple roots.
-        // split the curve in half and handle each half separately.
+        let base = arena.baseAddress! + depth * 4 * count
+        let slotA = UnsafeMutableBufferPointer(start: base,              count: count)
+        let slotB = UnsafeMutableBufferPointer(start: base + count,      count: count)
+        let slotC = UnsafeMutableBufferPointer(start: base + 2 * count,  count: count)
+        let slotD = UnsafeMutableBufferPointer(start: base + 3 * count,  count: count)
         guard upperBound - lowerBound < 0.8 else {
+            // Convergence too slow — split in half and handle each side separately.
             let rangeMid = Utils.linearInterpolate(rangeStart, rangeEnd, 0.5)
-            var curveRoots: [CGFloat] = []
-            let (left, right) = curve.split(at: 0.5)
-            curveRoots += rootsOfCurveMappedToRange(left, start: rangeStart, end: rangeMid, configuration: configuration)
-            curveRoots += rootsOfCurveMappedToRange(right, start: rangeMid, end: rangeEnd, configuration: configuration)
-            return curveRoots
+            deCasteljauSplit(input: coefficients, count: count, at: 0.5,
+                             left: slotB, right: slotC, scratch: slotA)
+            rootsCore(coefficients: UnsafeBufferPointer(slotB), count: count,
+                      start: rangeStart, end: rangeMid,
+                      configuration: configuration, arena: arena, depth: depth + 1, callback: callback)
+            rootsCore(coefficients: UnsafeBufferPointer(slotC), count: count,
+                      start: rangeMid, end: rangeEnd,
+                      configuration: configuration, arena: arena, depth: depth + 1, callback: callback)
+            return
         }
-        // split the curve over the range where the convex hull intersected the
-        // x-Axis and iterate.
-        var curveRoots: [CGFloat] = []
-        let subcurve = curve.split(from: lowerBound, to: upperBound)
+        // Narrow the curve to [lowerBound, upperBound] (equivalent to split(from:to:)).
+        // lowerBound and upperBound are always in [0,1] and lowerBound <= upperBound by construction.
+        let subcurvePtr: UnsafeBufferPointer<CGFloat>
+        if lowerBound == 0 {
+            // Only need the left portion of split at upperBound.
+            deCasteljauSplit(input: coefficients, count: count, at: upperBound,
+                             left: slotC, right: slotB, scratch: slotA)
+            subcurvePtr = UnsafeBufferPointer(slotC)
+        } else if upperBound == 1 {
+            // Only need the right portion of split at lowerBound.
+            deCasteljauSplit(input: coefficients, count: count, at: lowerBound,
+                             left: slotB, right: slotC, scratch: slotA)
+            subcurvePtr = UnsafeBufferPointer(slotC)
+        } else {
+            // General case: split at lowerBound, take right; then split right at mapped t2, take left.
+            deCasteljauSplit(input: coefficients, count: count, at: lowerBound,
+                             left: slotB, right: slotC, scratch: slotA)
+            let t2Mapped = (upperBound - lowerBound) / (1 - lowerBound)
+            deCasteljauSplit(input: UnsafeBufferPointer(slotC), count: count, at: t2Mapped,
+                             left: slotB, right: slotD, scratch: slotA)
+            subcurvePtr = UnsafeBufferPointer(slotB)
+        }
         func skippedRoot(between first: CGFloat, and second: CGFloat) -> Bool {
-            // due to floating point roundoff, it is possible (although rare)
-            // for the algorithm to sneak past a root. To avoid this problem
-            // we make sure the curve doesn't change sign between the
-            // boundaries of the current and next range
             return first > 0 && second < 0 || first < 0 && second > 0
         }
-        if skippedRoot(between: curve.coefficients.first!, and: subcurve.coefficients.first!) {
-            curveRoots.append(nextRangeStart)
+        if skippedRoot(between: coefficients[0], and: subcurvePtr[0]) {
+            callback(nextRangeStart)
         }
-        curveRoots += rootsOfCurveMappedToRange(subcurve, start: nextRangeStart, end: nextRangeEnd, configuration: configuration)
-        if skippedRoot(between: subcurve.coefficients.last!, and: curve.coefficients.last!) {
-            curveRoots.append(nextRangeEnd)
+        rootsCore(coefficients: subcurvePtr, count: count,
+                  start: nextRangeStart, end: nextRangeEnd,
+                  configuration: configuration, arena: arena, depth: depth + 1, callback: callback)
+        if skippedRoot(between: subcurvePtr[count - 1], and: coefficients[count - 1]) {
+            callback(nextRangeEnd)
         }
-        return curveRoots
     }
 }

--- a/BezierKit/Library/Utils.swift
+++ b/BezierKit/Library/Utils.swift
@@ -488,6 +488,23 @@ internal class Utils {
 
         // If either curve reduced by less than 20 %, convergence is slow — subdivide.
         if c1Ratio > 0.8 || c2Ratio > 0.8 {
+            // For tangent intersections at a shared endpoint, fat-line clipping near the
+            // endpoint gives ratio ≈ 1.0, causing exponential blowup.  When both sub-curves
+            // have already been narrowed to a small parameter range (fast convergence already
+            // did its job), detect exact shared endpoints directly rather than continuing to
+            // subdivide.  The range threshold is conservative: tangent cases reach this scale
+            // quickly via fast convergence, while nearly-coincident cases exhaust their budget
+            // long before reaching it.
+            let c1Range = c1Reduced.t2 - c1Reduced.t1
+            let c2Range = c2Reduced.t2 - c2Reduced.t1
+            if c1Range < 0.05 && c2Range < 0.05 {
+                let p1s = c1Reduced.curve.startingPoint; let p1e = c1Reduced.curve.endingPoint
+                let p2s = c2Reduced.curve.startingPoint; let p2e = c2Reduced.curve.endingPoint
+                if p1e == p2s { results.append(Intersection(t1: c1Reduced.t2, t2: c2Reduced.t1)); return true }
+                if p1e == p2e { results.append(Intersection(t1: c1Reduced.t2, t2: c2Reduced.t2)); return true }
+                if p1s == p2s { results.append(Intersection(t1: c1Reduced.t1, t2: c2Reduced.t1)); return true }
+                if p1s == p2e { results.append(Intersection(t1: c1Reduced.t1, t2: c2Reduced.t2)); return true }
+            }
             // Subdivide whichever has the larger global parameter range.
             if (c1Reduced.t2 - c1Reduced.t1) >= (c2Reduced.t2 - c2Reduced.t1) {
                 guard c1Reduced.canSplit else {

--- a/BezierKit/Library/Utils.swift
+++ b/BezierKit/Library/Utils.swift
@@ -186,13 +186,19 @@ internal class Utils {
         let p2 = Double(p2)
         let p3 = Double(p3)
         let d = -p0 + 3 * p1 - 3 * p2 + p3
-        let smallValue: Double = 1.0e-8
-        guard Swift.abs(d) >= smallValue else {
+        guard Swift.abs(d) > 0 else {
             // solve the quadratic polynomial at^2 + bt + c instead
             let a = (3 * p0 - 6 * p1 + 3 * p2)
             let b = (-3 * p0 + 3 * p1)
             let c = p0
             droots(CGFloat(c), CGFloat(b / 2.0 + c), CGFloat(a + b + c), callback: callback)
+            return
+        }
+        let scale = Swift.abs(p0) + 3 * Swift.abs(p1) + 3 * Swift.abs(p2) + Swift.abs(p3)
+        // When `d` is small relative to coefficient magnitudes, dividing by it amplifies rounding errors.
+        guard Swift.abs(d) >= 1.0e-4 * scale else {
+            BernsteinPolynomialN(coefficients: [CGFloat(p0), CGFloat(p1), CGFloat(p2), CGFloat(p3)])
+                .distinctRealRootsInUnitInterval().forEach(callback)
             return
         }
         let a = (3 * p0 - 6 * p1 + 3 * p2) / d

--- a/BezierKit/Library/Utils.swift
+++ b/BezierKit/Library/Utils.swift
@@ -335,70 +335,161 @@ internal class Utils {
 
     // MARK: - Bezier Clipping (Sederberg & Nishita, 1990)
 
-    // Given n Bernstein coefficients d(i) (curve at t_i = i/(n-1)) and a horizontal band
+    // Given n Bernstein coefficients d0..d3 (curve at t_i = i/(n-1)) and a horizontal band
     // [dLow, dHigh], returns the sub-interval [tMin, tMax] of [0,1] where the convex hull
     // of {(t_i, d(i))} intersects the band. Returns nil if hull and band are disjoint.
-    // Uses stack-allocated buffers for the hull indices to avoid heap allocation.
-    internal static func convexHullClipInterval(n: Int, d: (Int) -> CGFloat,
-                                                dLow: CGFloat, dHigh: CGFloat) -> (CGFloat, CGFloat)? {
-        let nf = CGFloat(n - 1)
-        var tMin = CGFloat.infinity
-        var tMax = -CGFloat.infinity
+    // d2 and d3 are only used when n > 2 and n > 3 respectively.
+    internal static func convexHullClipInterval(
+        d0: CGFloat, d1: CGFloat, d2: CGFloat, d3: CGFloat, n: Int,
+        dLow: CGFloat, dHigh: CGFloat
+    ) -> (CGFloat, CGFloat)? {
+        // Early exit: if all d values are on the same side of the band, no intersection possible.
+        var dvMin = min(d0, d1)
+        var dvMax = max(d0, d1)
+        if n > 2 { dvMin = min(dvMin, d2); dvMax = max(dvMax, d2) }
+        if n > 3 { dvMin = min(dvMin, d3); dvMax = max(dvMax, d3) }
+        guard dvMax >= dLow && dvMin <= dHigh else { return nil }
+        // Fast path: all control points inside the band → entire curve is inside.
+        if dvMin >= dLow && dvMax <= dHigh { return (0, 1) }
 
-        // Precompute all d-values once to avoid repeated closure calls during hull building.
-        var dv: (CGFloat, CGFloat, CGFloat, CGFloat) = (d(0), d(1), 0, 0)
-        if n > 2 { dv.2 = d(2) }
-        if n > 3 { dv.3 = d(3) }
-        func dAt(_ i: Int) -> CGFloat {
-            switch i { case 0: return dv.0; case 1: return dv.1; case 2: return dv.2; default: return dv.3 }
-        }
-
-        func cross2d(_ a: Int, _ b: Int, _ c: Int) -> CGFloat {
-            let ta = CGFloat(a)/nf; let da = dAt(a)
-            let tb = CGFloat(b)/nf; let db = dAt(b)
-            let tc = CGFloat(c)/nf; let dc = dAt(c)
-            return (tb - ta) * (dc - da) - (db - da) * (tc - ta)
-        }
-        func processEdge(ta: CGFloat, da: CGFloat, tb: CGFloat, db: CGFloat) {
-            if da >= dLow && da <= dHigh { tMin = min(tMin, ta); tMax = max(tMax, ta) }
-            let dDelta = db - da
-            if abs(dDelta) > 0 {
-                let paramLow  = (dLow  - da) / dDelta
-                if paramLow  >= 0 && paramLow  <= 1 { let t = ta + paramLow  * (tb - ta); tMin = min(tMin, t); tMax = max(tMax, t) }
-                let paramHigh = (dHigh - da) / dDelta
-                if paramHigh >= 0 && paramHigh <= 1 { let t = ta + paramHigh * (tb - ta); tMin = min(tMin, t); tMax = max(tMax, t) }
+        // n=4 specialization (cubic curves — by far the most common case).
+        // Eliminates the generic loop + withUnsafeTemporaryAllocation overhead by using a
+        // static branch tree over precomputed cross products. tMin/tMax are passed explicitly
+        // to avoid captured-var exclusivity overhead even after inlining.
+        if n == 4 {
+            // Processes one convex hull edge from (ta, da) to (ta+dt, db) against [dLow,dHigh].
+            // Returns updated (lo, hi). With @inline(__always), the call sites become pure
+            // local-variable arithmetic — no closure captures, no swift_beginAccess overhead.
+            @inline(__always) func check(_ da: CGFloat, _ db: CGFloat,
+                                         _ ta: CGFloat, _ dt: CGFloat,
+                                         _ lo: CGFloat, _ hi: CGFloat) -> (CGFloat, CGFloat) {
+                var lo = lo, hi = hi
+                if da >= dLow && da <= dHigh { if ta < lo { lo = ta }; if ta > hi { hi = ta } }
+                let dDelta = db - da
+                if dDelta != 0 {
+                    // Sign-based crossing detection: avoid division when the edge doesn't cross
+                    // the boundary (the sign product is positive when both ends are on the same side).
+                    let dLowA = dLow - da; let dLowB = dLow - db
+                    if dLowA * dLowB <= 0 { let t = ta + dLowA * dt / dDelta; if t < lo { lo = t }; if t > hi { hi = t } }
+                    let dHighA = dHigh - da; let dHighB = dHigh - db
+                    if dHighA * dHighB <= 0 { let t = ta + dHighA * dt / dDelta; if t < lo { lo = t }; if t > hi { hi = t } }
+                }
+                return (lo, hi)
             }
+
+            var tMin = CGFloat.infinity, tMax = -CGFloat.infinity
+
+            // Cross products proportional to cross2d for the 4 uniformly-spaced points
+            // (t ∈ {0, 1/3, 2/3, 1}), sharing sign with the original cross2d formulation:
+            //   c012 = cross2d(0,1,2) = d0 - 2·d1 + d2
+            //   c023 = cross2d(0,2,3) = d0 - 3·d2 + 2·d3
+            //   c123 = cross2d(1,2,3) = d1 - 2·d2 + d3
+            //   c013 = cross2d(0,1,3) = 2·d0 - 3·d1 + d3
+            let c012 = d0 - 2*d1 + d2
+
+            // Lower hull: pop vertex when cross2d ≤ 0 (right turn or collinear).
+            if c012 <= 0 {
+                let c023 = d0 - 3*d2 + 2*d3
+                if c023 <= 0 {
+                    (tMin, tMax) = check(d0, d3, 0,       1,       tMin, tMax) // hull {0,3}
+                } else {
+                    (tMin, tMax) = check(d0, d2, 0,       2.0/3,   tMin, tMax) // hull {0,2,3}
+                    (tMin, tMax) = check(d2, d3, 2.0/3,   1.0/3,   tMin, tMax)
+                }
+            } else {
+                let c123 = d1 - 2*d2 + d3
+                if c123 <= 0 {
+                    let c013 = 2*d0 - 3*d1 + d3
+                    if c013 <= 0 {
+                        (tMin, tMax) = check(d0, d3, 0,       1,       tMin, tMax) // hull {0,3}
+                    } else {
+                        (tMin, tMax) = check(d0, d1, 0,       1.0/3,   tMin, tMax) // hull {0,1,3}
+                        (tMin, tMax) = check(d1, d3, 1.0/3,   2.0/3,   tMin, tMax)
+                    }
+                } else {
+                    (tMin, tMax) = check(d0, d1, 0,       1.0/3,   tMin, tMax) // hull {0,1,2,3}
+                    (tMin, tMax) = check(d1, d2, 1.0/3,   1.0/3,   tMin, tMax)
+                    (tMin, tMax) = check(d2, d3, 2.0/3,   1.0/3,   tMin, tMax)
+                }
+            }
+
+            // Upper hull: pop vertex when cross2d ≥ 0 (left turn or collinear).
+            if c012 >= 0 {
+                let c023 = d0 - 3*d2 + 2*d3
+                if c023 >= 0 {
+                    (tMin, tMax) = check(d0, d3, 0,       1,       tMin, tMax)
+                } else {
+                    (tMin, tMax) = check(d0, d2, 0,       2.0/3,   tMin, tMax)
+                    (tMin, tMax) = check(d2, d3, 2.0/3,   1.0/3,   tMin, tMax)
+                }
+            } else {
+                let c123 = d1 - 2*d2 + d3
+                if c123 >= 0 {
+                    let c013 = 2*d0 - 3*d1 + d3
+                    if c013 >= 0 {
+                        (tMin, tMax) = check(d0, d3, 0,       1,       tMin, tMax)
+                    } else {
+                        (tMin, tMax) = check(d0, d1, 0,       1.0/3,   tMin, tMax)
+                        (tMin, tMax) = check(d1, d3, 1.0/3,   2.0/3,   tMin, tMax)
+                    }
+                } else {
+                    (tMin, tMax) = check(d0, d1, 0,       1.0/3,   tMin, tMax)
+                    (tMin, tMax) = check(d1, d2, 1.0/3,   1.0/3,   tMin, tMax)
+                    (tMin, tMax) = check(d2, d3, 2.0/3,   1.0/3,   tMin, tMax)
+                }
+            }
+
+            // d3 at t=1 is always the final vertex of both hulls.
+            if d3 >= dLow && d3 <= dHigh { if tMin > 1 { tMin = 1 }; if tMax < 1 { tMax = 1 } }
+
+            guard tMin <= tMax else { return nil }
+            return (max(0, tMin), min(1, tMax))
         }
 
-        // Build lower and upper convex hulls using stack-allocated fixed-size buffers
-        // (curves have at most 4 control points, so hull length ≤ 4).
-        var lower: (Int, Int, Int, Int) = (0, 0, 0, 0); var lc = 0
-        var upper: (Int, Int, Int, Int) = (0, 0, 0, 0); var uc = 0
-        func lowerAt(_ k: Int) -> Int {
-            switch k { case 0: return lower.0; case 1: return lower.1; case 2: return lower.2; default: return lower.3 }
-        }
-        func upperAt(_ k: Int) -> Int {
-            switch k { case 0: return upper.0; case 1: return upper.1; case 2: return upper.2; default: return upper.3 }
-        }
-        func setLower(_ k: Int, _ v: Int) {
-            switch k { case 0: lower.0 = v; case 1: lower.1 = v; case 2: lower.2 = v; default: lower.3 = v }
-        }
-        func setUpper(_ k: Int, _ v: Int) {
-            switch k { case 0: upper.0 = v; case 1: upper.1 = v; case 2: upper.2 = v; default: upper.3 = v }
-        }
-        for i in 0..<n {
-            while lc >= 2 && cross2d(lowerAt(lc-2), lowerAt(lc-1), i) <= 0 { lc -= 1 }
-            setLower(lc, i); lc += 1
-            while uc >= 2 && cross2d(upperAt(uc-2), upperAt(uc-1), i) >= 0 { uc -= 1 }
-            setUpper(uc, i); uc += 1
-        }
-        for i in 0..<lc-1 { processEdge(ta: CGFloat(lowerAt(i))/nf, da: dAt(lowerAt(i)), tb: CGFloat(lowerAt(i+1))/nf, db: dAt(lowerAt(i+1))) }
-        if lc > 0 { let last = lowerAt(lc-1); let dv = dAt(last); if dv >= dLow && dv <= dHigh { let t = CGFloat(last)/nf; tMin = min(tMin, t); tMax = max(tMax, t) } }
-        for i in 0..<uc-1 { processEdge(ta: CGFloat(upperAt(i))/nf, da: dAt(upperAt(i)), tb: CGFloat(upperAt(i+1))/nf, db: dAt(upperAt(i+1))) }
-        if uc > 0 { let last = upperAt(uc-1); let dv = dAt(last); if dv >= dLow && dv <= dHigh { let t = CGFloat(last)/nf; tMin = min(tMin, t); tMax = max(tMax, t) } }
+        // Generic path for n ≠ 4 (quadratic curves, n=3).
+        let nf = CGFloat(n - 1)
 
-        guard tMin <= tMax else { return nil }
-        return (max(0, tMin), min(1, tMax))
+        func dAt(_ i: Int) -> CGFloat {
+            switch i { case 0: return d0; case 1: return d1; default: return d2 }
+        }
+        func cross2d(_ a: Int, _ b: Int, _ c: Int) -> CGFloat {
+            let da = dAt(a); let db = dAt(b); let dc = dAt(c)
+            return CGFloat(b - a) * (dc - da) - (db - da) * CGFloat(c - a)
+        }
+
+        return withUnsafeTemporaryAllocation(of: Int.self, capacity: n * 2) { buf in
+            let lower = buf.baseAddress!
+            let upper = buf.baseAddress! + n
+            var lc = 0, uc = 0
+            var tMin = CGFloat.infinity
+            var tMax = -CGFloat.infinity
+
+            for i in 0..<n {
+                while lc >= 2 && cross2d(lower[lc-2], lower[lc-1], i) <= 0 { lc -= 1 }
+                lower[lc] = i; lc += 1
+                while uc >= 2 && cross2d(upper[uc-2], upper[uc-1], i) >= 0 { uc -= 1 }
+                upper[uc] = i; uc += 1
+            }
+            @inline(__always) func processEdge(_ ai: Int, _ bi: Int) {
+                let ta = CGFloat(ai) / nf; let da = dAt(ai)
+                let tb = CGFloat(bi) / nf; let db = dAt(bi)
+                if da >= dLow && da <= dHigh { tMin = min(tMin, ta); tMax = max(tMax, ta) }
+                let dDelta = db - da
+                if dDelta != 0 {
+                    let dt = tb - ta
+                    let dLowA = dLow - da; let dLowB = dLow - db
+                    if dLowA * dLowB <= 0 { let t = ta + dLowA * dt / dDelta; if t < tMin { tMin = t }; if t > tMax { tMax = t } }
+                    let dHighA = dHigh - da; let dHighB = dHigh - db
+                    if dHighA * dHighB <= 0 { let t = ta + dHighA * dt / dDelta; if t < tMin { tMin = t }; if t > tMax { tMax = t } }
+                }
+            }
+            for i in 0..<lc-1 { processEdge(lower[i], lower[i+1]) }
+            if lc > 0 { let last = lower[lc-1]; let dv = dAt(last); if dv >= dLow && dv <= dHigh { let t = CGFloat(last)/nf; tMin = min(tMin, t); tMax = max(tMax, t) } }
+            for i in 0..<uc-1 { processEdge(upper[i], upper[i+1]) }
+            if uc > 0 { let last = upper[uc-1]; let dv = dAt(last); if dv >= dLow && dv <= dHigh { let t = CGFloat(last)/nf; tMin = min(tMin, t); tMax = max(tMax, t) } }
+            guard tMin <= tMax else { return nil }
+            return (max(0, tMin), min(1, tMax))
+        }
     }
 
     // Compute the fat line of `other` and clip `curve`'s [0,1] parameter range
@@ -409,19 +500,40 @@ internal class Utils {
         let dir = qn - q0
         guard dir.lengthSquared > 0 else { return (0, 1) }
 
-        // Fat-line signed-distance bounds from Q's internal control points (no heap allocation).
-        var dMin: CGFloat = 0
-        var dMax: CGFloat = 0
-        other.withPointsDo { n, pt in
-            for i in 1..<n-1 {
-                let d = (pt(i) - q0).cross(dir)
-                if d < dMin { dMin = d } else if d > dMax { dMax = d }
+        // Tight fat-line bounds (Sederberg & Nishita 1990):
+        // For a quadratic, the curve lies within ½ of the control point's distance from the chord.
+        // For a cubic when both interior points are on the same side, within ¾ of the max.
+        // Tighter bounds → fewer bezier clipping iterations.
+        // Return-value pattern avoids mutable var captures (and the swift_beginAccess overhead they incur).
+        let (dMin, dMax) = other.withPointsDo { n, pt -> (CGFloat, CGFloat) in
+            if n == 3 {
+                // Quadratic: single interior point, tight factor = 1/2
+                let d = 0.5 * (pt(1) - q0).cross(dir)
+                return (min(0, d), max(0, d))
+            } else if n == 4 {
+                // Cubic: two interior points; use 3/4 factor when both have the same sign
+                let d1 = (pt(1) - q0).cross(dir)
+                let d2 = (pt(2) - q0).cross(dir)
+                let factor: CGFloat = (d1 * d2 > 0) ? 0.75 : 1.0
+                return (min(0, factor * min(d1, d2)), max(0, factor * max(d1, d2)))
+            } else {
+                var lo: CGFloat = 0, hi: CGFloat = 0
+                for i in 1..<n-1 {
+                    let d = (pt(i) - q0).cross(dir)
+                    if d < lo { lo = d } else if d > hi { hi = d }
+                }
+                return (lo, hi)
             }
         }
 
-        // Clip curve against fat line: distances computed on demand via closure (no heap allocation).
+        // Pre-compute all d values before entering convexHullClipInterval to avoid
+        // indirect closure dispatch inside the inner loop.
         return curve.withPointsDo { n, pt in
-            convexHullClipInterval(n: n, d: { (pt($0) - q0).cross(dir) }, dLow: dMin, dHigh: dMax)
+            let e0 = (pt(0) - q0).cross(dir)
+            let e1 = (pt(1) - q0).cross(dir)
+            let e2: CGFloat = n > 2 ? (pt(2) - q0).cross(dir) : 0
+            let e3: CGFloat = n > 3 ? (pt(3) - q0).cross(dir) : 0
+            return convexHullClipInterval(d0: e0, d1: e1, d2: e2, d3: e3, n: n, dLow: dMin, dHigh: dMax)
         }
     }
 
@@ -438,110 +550,122 @@ internal class Utils {
         let maximumIterations    = 900
         let maximumIntersections = c1.curve.order * c2.curve.order
 
-        totalIterations += 1
-        guard totalIterations  <= maximumIterations    else { return false }
-        guard results.count    <= maximumIntersections else { return false }
+        // Quick bounding-box rejection using control polygon bounds (cheap: no root-finding).
+        guard c1.curve.controlPolygonBounds.overlaps(c2.curve.controlPolygonBounds) else { return true }
 
-        // Quick bounding-box rejection.
-        guard c1.curve.boundingBox.overlaps(c2.curve.boundingBox) else { return true }
+        var c1 = c1
+        var c2 = c2
 
-        // Clip c1 using the fat line of c2.
-        guard let clip1 = fatLineClip(curve: c1.curve, fatOf: c2.curve) else { return true }
-        let c1Ratio   = clip1.1 - clip1.0
-        let c1Reduced = c1.split(from: clip1.0, to: clip1.1)
+        while true {
+            totalIterations += 1
+            guard totalIterations  <= maximumIterations    else { return false }
+            guard results.count    <= maximumIntersections else { return false }
 
-        // Clip c2 using the fat line of the (possibly narrowed) c1.
-        guard let clip2 = fatLineClip(curve: c2.curve, fatOf: c1Reduced.curve) else { return true }
-        let c2Ratio   = clip2.1 - clip2.0
-        let c2Reduced = c2.split(from: clip2.0, to: clip2.1)
+            // Clip c1 using the fat line of c2.
+            guard let clip1 = fatLineClip(curve: c1.curve, fatOf: c2.curve) else { return true }
+            let c1Ratio   = clip1.1 - clip1.0
+            let c1Reduced = c1.split(from: clip1.0, to: clip1.1)
 
-        // Geometric convergence check: both subcurves fit inside the accuracy threshold.
-        let b1 = c1Reduced.curve.boundingBox
-        let b2 = c2Reduced.curve.boundingBox
-        if b1.size.x + b1.size.y < accuracy && b2.size.x + b2.size.y < accuracy {
-            // Reject false positives: nearby non-intersecting sub-curves can both pass the
-            // size threshold. Require the reduced bounding boxes to be spatially close.
-            // Expand by `accuracy` to absorb floating-point rounding on degenerate curves.
-            guard b1.max.x + accuracy >= b2.min.x && b2.max.x + accuracy >= b1.min.x &&
-                  b1.max.y + accuracy >= b2.min.y && b2.max.y + accuracy >= b1.min.y else { return true }
-            let p1s = c1Reduced.curve.startingPoint
-            let p1e = c1Reduced.curve.endingPoint
-            let p2s = c2Reduced.curve.startingPoint
-            let p2e = c2Reduced.curve.endingPoint
-            var t1: CGFloat
-            var t2: CGFloat
-            // Exact shared-endpoint matching: point(at:0) and point(at:1) return the
-            // raw control points, so these equalities are bit-for-bit when curves share
-            // an original endpoint.
-            if p1s == p2s {
-                t1 = c1Reduced.t1; t2 = c2Reduced.t1
-            } else if p1s == p2e {
-                t1 = c1Reduced.t1; t2 = c2Reduced.t2
-            } else if p1e == p2s {
-                t1 = c1Reduced.t2; t2 = c2Reduced.t1
-            } else if p1e == p2e {
-                t1 = c1Reduced.t2; t2 = c2Reduced.t2
-            } else {
-                let l1 = LineSegment(p0: p1s, p1: p1e)
-                let l2 = LineSegment(p0: p2s, p1: p2e)
-                if l1.p0 != l1.p1, l2.p0 != l2.p1,
-                   let ix = l1.intersections(with: l2, checkCoincidence: false).first {
-                    t1 = ix.t1 * c1Reduced.t2 + (1 - ix.t1) * c1Reduced.t1
-                    t2 = ix.t2 * c2Reduced.t2 + (1 - ix.t2) * c2Reduced.t1
+            // Clip c2 using the fat line of the (possibly narrowed) c1.
+            guard let clip2 = fatLineClip(curve: c2.curve, fatOf: c1Reduced.curve) else { return true }
+            let c2Ratio   = clip2.1 - clip2.0
+            let c2Reduced = c2.split(from: clip2.0, to: clip2.1)
+
+            // Geometric convergence check: both subcurves fit inside the accuracy threshold.
+            let b1 = c1Reduced.curve.boundingBox
+            let b2 = c2Reduced.curve.boundingBox
+            if b1.size.x + b1.size.y < accuracy && b2.size.x + b2.size.y < accuracy {
+                // Reject false positives: nearby non-intersecting sub-curves can both pass the
+                // size threshold. Require the reduced bounding boxes to be spatially close.
+                // Expand by `accuracy` to absorb floating-point rounding on degenerate curves.
+                guard b1.max.x + accuracy >= b2.min.x && b2.max.x + accuracy >= b1.min.x &&
+                      b1.max.y + accuracy >= b2.min.y && b2.max.y + accuracy >= b1.min.y else { return true }
+                let p1s = c1Reduced.curve.startingPoint
+                let p1e = c1Reduced.curve.endingPoint
+                let p2s = c2Reduced.curve.startingPoint
+                let p2e = c2Reduced.curve.endingPoint
+                var t1: CGFloat
+                var t2: CGFloat
+                if p1s == p2s {
+                    t1 = c1Reduced.t1; t2 = c2Reduced.t1
+                } else if p1s == p2e {
+                    t1 = c1Reduced.t1; t2 = c2Reduced.t2
+                } else if p1e == p2s {
+                    t1 = c1Reduced.t2; t2 = c2Reduced.t1
+                } else if p1e == p2e {
+                    t1 = c1Reduced.t2; t2 = c2Reduced.t2
                 } else {
-                    t1 = 0.5 * (c1Reduced.t1 + c1Reduced.t2)
-                    t2 = 0.5 * (c2Reduced.t1 + c2Reduced.t2)
+                    // Newton-Raphson from midpoint. Sub-curves are tiny at convergence so
+                    // the root is always within 0.5 of the midpoint — first step stays in [0,1].
+                    // F(u,v) = c1(u) - c2(v) = 0; J = [d1, -d2].
+                    // du = -F.cross(d2) / d1.cross(d2),  dv = d1.cross(F) / d1.cross(d2)
+                    var u: CGFloat = 0.5, v: CGFloat = 0.5
+                    for _ in 0..<6 {
+                        let f = c1Reduced.curve.point(at: u) - c2Reduced.curve.point(at: v)
+                        let d1 = c1Reduced.curve.derivative(at: u)
+                        let d2 = c2Reduced.curve.derivative(at: v)
+                        let denom = d1.cross(d2)
+                        guard denom != 0 else { break }
+                        let du = -f.cross(d2) / denom
+                        let dv = d1.cross(f) / denom
+                        u += du; if u < 0 { u = 0 } else if u > 1 { u = 1 }
+                        v += dv; if v < 0 { v = 0 } else if v > 1 { v = 1 }
+                        guard du * du + dv * dv > CGFloat(1e-28) else { break }
+                    }
+                    t1 = u * c1Reduced.t2 + (1 - u) * c1Reduced.t1
+                    t2 = v * c2Reduced.t2 + (1 - v) * c2Reduced.t1
                 }
+                results.append(Intersection(t1: t1, t2: t2))
+                return true
             }
-            results.append(Intersection(t1: t1, t2: t2))
-            return true
-        }
 
-        // If either curve reduced by less than 20 %, convergence is slow — subdivide.
-        if c1Ratio > 0.8 || c2Ratio > 0.8 {
-            // For tangent intersections at a shared endpoint, fat-line clipping near the
-            // endpoint gives ratio ≈ 1.0, causing exponential blowup.  When both sub-curves
-            // have already been narrowed to a small parameter range (fast convergence already
-            // did its job), detect exact shared endpoints directly rather than continuing to
-            // subdivide.  The range threshold is conservative: tangent cases reach this scale
-            // quickly via fast convergence, while nearly-coincident cases exhaust their budget
-            // long before reaching it.
-            let c1Range = c1Reduced.t2 - c1Reduced.t1
-            let c2Range = c2Reduced.t2 - c2Reduced.t1
-            if c1Range < 0.05 && c2Range < 0.05 {
-                let p1s = c1Reduced.curve.startingPoint; let p1e = c1Reduced.curve.endingPoint
-                let p2s = c2Reduced.curve.startingPoint; let p2e = c2Reduced.curve.endingPoint
-                if p1e == p2s { results.append(Intersection(t1: c1Reduced.t2, t2: c2Reduced.t1)); return true }
-                if p1e == p2e { results.append(Intersection(t1: c1Reduced.t2, t2: c2Reduced.t2)); return true }
-                if p1s == p2s { results.append(Intersection(t1: c1Reduced.t1, t2: c2Reduced.t1)); return true }
-                if p1s == p2e { results.append(Intersection(t1: c1Reduced.t1, t2: c2Reduced.t2)); return true }
-            }
-            // Subdivide whichever has the larger global parameter range.
-            if (c1Reduced.t2 - c1Reduced.t1) >= (c2Reduced.t2 - c2Reduced.t1) {
-                guard c1Reduced.canSplit else {
-                    guard c2Reduced.canSplit else { return true }
+            // If either curve reduced by less than 20 %, convergence is slow — subdivide.
+            if c1Ratio > 0.8 || c2Ratio > 0.8 {
+                // For tangent intersections at a shared endpoint, fat-line clipping near the
+                // endpoint gives ratio ≈ 1.0, causing exponential blowup.  When both sub-curves
+                // have already been narrowed to a small parameter range (fast convergence already
+                // did its job), detect exact shared endpoints directly rather than continuing to
+                // subdivide.  The range threshold is conservative: tangent cases reach this scale
+                // quickly via fast convergence, while nearly-coincident cases exhaust their budget
+                // long before reaching it.
+                let c1Range = c1Reduced.t2 - c1Reduced.t1
+                let c2Range = c2Reduced.t2 - c2Reduced.t1
+                if c1Range < 0.05 && c2Range < 0.05 {
+                    let p1s = c1Reduced.curve.startingPoint; let p1e = c1Reduced.curve.endingPoint
+                    let p2s = c2Reduced.curve.startingPoint; let p2e = c2Reduced.curve.endingPoint
+                    if p1e == p2s { results.append(Intersection(t1: c1Reduced.t2, t2: c2Reduced.t1)); return true }
+                    if p1e == p2e { results.append(Intersection(t1: c1Reduced.t2, t2: c2Reduced.t2)); return true }
+                    if p1s == p2s { results.append(Intersection(t1: c1Reduced.t1, t2: c2Reduced.t1)); return true }
+                    if p1s == p2e { results.append(Intersection(t1: c1Reduced.t1, t2: c2Reduced.t2)); return true }
+                }
+                // Subdivide whichever has the larger global parameter range.
+                if (c1Reduced.t2 - c1Reduced.t1) >= (c2Reduced.t2 - c2Reduced.t1) {
+                    guard c1Reduced.canSplit else {
+                        guard c2Reduced.canSplit else { return true }
+                        let h = c2Reduced.split(at: 0.5)
+                        guard bezierClipping(c1Reduced, h.left,  &results, accuracy, &totalIterations) else { return false }
+                        return  bezierClipping(c1Reduced, h.right, &results, accuracy, &totalIterations)
+                    }
+                    let h = c1Reduced.split(at: 0.5)
+                    guard bezierClipping(h.left,  c2Reduced, &results, accuracy, &totalIterations) else { return false }
+                    return  bezierClipping(h.right, c2Reduced, &results, accuracy, &totalIterations)
+                } else {
+                    guard c2Reduced.canSplit else {
+                        guard c1Reduced.canSplit else { return true }
+                        let h = c1Reduced.split(at: 0.5)
+                        guard bezierClipping(h.left,  c2Reduced, &results, accuracy, &totalIterations) else { return false }
+                        return  bezierClipping(h.right, c2Reduced, &results, accuracy, &totalIterations)
+                    }
                     let h = c2Reduced.split(at: 0.5)
                     guard bezierClipping(c1Reduced, h.left,  &results, accuracy, &totalIterations) else { return false }
                     return  bezierClipping(c1Reduced, h.right, &results, accuracy, &totalIterations)
                 }
-                let h = c1Reduced.split(at: 0.5)
-                guard bezierClipping(h.left,  c2Reduced, &results, accuracy, &totalIterations) else { return false }
-                return  bezierClipping(h.right, c2Reduced, &results, accuracy, &totalIterations)
-            } else {
-                guard c2Reduced.canSplit else {
-                    guard c1Reduced.canSplit else { return true }
-                    let h = c1Reduced.split(at: 0.5)
-                    guard bezierClipping(h.left,  c2Reduced, &results, accuracy, &totalIterations) else { return false }
-                    return  bezierClipping(h.right, c2Reduced, &results, accuracy, &totalIterations)
-                }
-                let h = c2Reduced.split(at: 0.5)
-                guard bezierClipping(c1Reduced, h.left,  &results, accuracy, &totalIterations) else { return false }
-                return  bezierClipping(c1Reduced, h.right, &results, accuracy, &totalIterations)
             }
-        }
 
-        // Good convergence — continue alternating clipping passes.
-        return bezierClipping(c1Reduced, c2Reduced, &results, accuracy, &totalIterations)
+            // Good convergence — continue alternating clipping passes.
+            c1 = c1Reduced
+            c2 = c2Reduced
+        }
     }
     // swiftlint:enable function_parameter_count
 

--- a/BezierKit/Library/Utils.swift
+++ b/BezierKit/Library/Utils.swift
@@ -28,20 +28,25 @@ internal extension Array where Element: Comparable {
 
 internal class Utils {
 
-    private static let binomialTable: [[CGFloat]] = [[1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                              [1, 1, 0, 0, 0, 0, 0, 0, 0, 0],
-                                              [1, 2, 1, 0, 0, 0, 0, 0, 0, 0],
-                                              [1, 3, 3, 1, 0, 0, 0, 0, 0, 0],
-                                              [1, 4, 6, 4, 1, 0, 0, 0, 0, 0],
-                                              [1, 5, 10, 10, 5, 1, 0, 0, 0, 0],
-                                              [1, 6, 15, 20, 15, 6, 1, 0, 0, 0],
-                                              [1, 7, 21, 35, 35, 21, 7, 1, 0, 0],
-                                              [1, 8, 28, 56, 70, 56, 28, 8, 1, 0],
-                                              [1, 9, 36, 84, 126, 126, 84, 36, 9, 1]]
+    // Flat 10×10 table (row-major, stride 10) avoids the double heap indirection of [[CGFloat]].
+    // swiftlint:disable comma
+    private static let binomialTable: [CGFloat] = [
+        1,  0,   0,   0,   0,   0,  0,  0, 0, 0,  // n=0
+        1,  1,   0,   0,   0,   0,  0,  0, 0, 0,  // n=1
+        1,  2,   1,   0,   0,   0,  0,  0, 0, 0,  // n=2
+        1,  3,   3,   1,   0,   0,  0,  0, 0, 0,  // n=3
+        1,  4,   6,   4,   1,   0,  0,  0, 0, 0,  // n=4
+        1,  5,  10,  10,   5,   1,  0,  0, 0, 0,  // n=5
+        1,  6,  15,  20,  15,   6,  1,  0, 0, 0,  // n=6
+        1,  7,  21,  35,  35,  21,  7,  1, 0, 0,  // n=7
+        1,  8,  28,  56,  70,  56, 28,  8, 1, 0,  // n=8
+        1,  9,  36,  84, 126, 126, 84, 36, 9, 1   // n=9
+    ]
+    // swiftlint:enable comma
 
     static func binomialCoefficient(_ n: Int, choose k: Int) -> CGFloat {
         precondition(n >= 0 && k >= 0 && n <= 9 && k <= 9)
-        return binomialTable[n][k]
+        return binomialTable[n &* 10 &+ k]
     }
 
     // float precision significant decimal

--- a/BezierKit/Library/Utils.swift
+++ b/BezierKit/Library/Utils.swift
@@ -322,6 +322,201 @@ internal class Utils {
         return true
     }
 
+    // MARK: - Bezier Clipping (Sederberg & Nishita, 1990)
+
+    // Given n Bernstein coefficients d(i) (curve at t_i = i/(n-1)) and a horizontal band
+    // [dLow, dHigh], returns the sub-interval [tMin, tMax] of [0,1] where the convex hull
+    // of {(t_i, d(i))} intersects the band. Returns nil if hull and band are disjoint.
+    // Uses stack-allocated buffers for the hull indices to avoid heap allocation.
+    internal static func convexHullClipInterval(n: Int, d: (Int) -> CGFloat,
+                                                dLow: CGFloat, dHigh: CGFloat) -> (CGFloat, CGFloat)? {
+        let nf = CGFloat(n - 1)
+        var tMin = CGFloat.infinity
+        var tMax = -CGFloat.infinity
+
+        // Precompute all d-values once to avoid repeated closure calls during hull building.
+        var dv: (CGFloat, CGFloat, CGFloat, CGFloat) = (d(0), d(1), 0, 0)
+        if n > 2 { dv.2 = d(2) }
+        if n > 3 { dv.3 = d(3) }
+        func dAt(_ i: Int) -> CGFloat {
+            switch i { case 0: return dv.0; case 1: return dv.1; case 2: return dv.2; default: return dv.3 }
+        }
+
+        func cross2d(_ a: Int, _ b: Int, _ c: Int) -> CGFloat {
+            let ta = CGFloat(a)/nf; let da = dAt(a)
+            let tb = CGFloat(b)/nf; let db = dAt(b)
+            let tc = CGFloat(c)/nf; let dc = dAt(c)
+            return (tb - ta) * (dc - da) - (db - da) * (tc - ta)
+        }
+        func processEdge(ta: CGFloat, da: CGFloat, tb: CGFloat, db: CGFloat) {
+            if da >= dLow && da <= dHigh { tMin = min(tMin, ta); tMax = max(tMax, ta) }
+            let dDelta = db - da
+            if abs(dDelta) > 0 {
+                let paramLow  = (dLow  - da) / dDelta
+                if paramLow  >= 0 && paramLow  <= 1 { let t = ta + paramLow  * (tb - ta); tMin = min(tMin, t); tMax = max(tMax, t) }
+                let paramHigh = (dHigh - da) / dDelta
+                if paramHigh >= 0 && paramHigh <= 1 { let t = ta + paramHigh * (tb - ta); tMin = min(tMin, t); tMax = max(tMax, t) }
+            }
+        }
+
+        // Build lower and upper convex hulls using stack-allocated fixed-size buffers
+        // (curves have at most 4 control points, so hull length ≤ 4).
+        var lower: (Int, Int, Int, Int) = (0, 0, 0, 0); var lc = 0
+        var upper: (Int, Int, Int, Int) = (0, 0, 0, 0); var uc = 0
+        func lowerAt(_ k: Int) -> Int {
+            switch k { case 0: return lower.0; case 1: return lower.1; case 2: return lower.2; default: return lower.3 }
+        }
+        func upperAt(_ k: Int) -> Int {
+            switch k { case 0: return upper.0; case 1: return upper.1; case 2: return upper.2; default: return upper.3 }
+        }
+        func setLower(_ k: Int, _ v: Int) {
+            switch k { case 0: lower.0 = v; case 1: lower.1 = v; case 2: lower.2 = v; default: lower.3 = v }
+        }
+        func setUpper(_ k: Int, _ v: Int) {
+            switch k { case 0: upper.0 = v; case 1: upper.1 = v; case 2: upper.2 = v; default: upper.3 = v }
+        }
+        for i in 0..<n {
+            while lc >= 2 && cross2d(lowerAt(lc-2), lowerAt(lc-1), i) <= 0 { lc -= 1 }
+            setLower(lc, i); lc += 1
+            while uc >= 2 && cross2d(upperAt(uc-2), upperAt(uc-1), i) >= 0 { uc -= 1 }
+            setUpper(uc, i); uc += 1
+        }
+        for i in 0..<lc-1 { processEdge(ta: CGFloat(lowerAt(i))/nf, da: dAt(lowerAt(i)), tb: CGFloat(lowerAt(i+1))/nf, db: dAt(lowerAt(i+1))) }
+        if lc > 0 { let last = lowerAt(lc-1); let dv = dAt(last); if dv >= dLow && dv <= dHigh { let t = CGFloat(last)/nf; tMin = min(tMin, t); tMax = max(tMax, t) } }
+        for i in 0..<uc-1 { processEdge(ta: CGFloat(upperAt(i))/nf, da: dAt(upperAt(i)), tb: CGFloat(upperAt(i+1))/nf, db: dAt(upperAt(i+1))) }
+        if uc > 0 { let last = upperAt(uc-1); let dv = dAt(last); if dv >= dLow && dv <= dHigh { let t = CGFloat(last)/nf; tMin = min(tMin, t); tMax = max(tMax, t) } }
+
+        guard tMin <= tMax else { return nil }
+        return (max(0, tMin), min(1, tMax))
+    }
+
+    // Compute the fat line of `other` and clip `curve`'s [0,1] parameter range
+    // to where it might intersect `other`. Returns nil if no intersection possible.
+    private static func fatLineClip<C1: NonlinearBezierCurve, C2: NonlinearBezierCurve>(curve: C1, fatOf other: C2) -> (CGFloat, CGFloat)? {
+        let q0  = other.startingPoint
+        let qn  = other.endingPoint
+        let dir = qn - q0
+        guard dir.lengthSquared > 0 else { return (0, 1) }
+
+        // Fat-line signed-distance bounds from Q's internal control points (no heap allocation).
+        var dMin: CGFloat = 0
+        var dMax: CGFloat = 0
+        other.withPointsDo { n, pt in
+            for i in 1..<n-1 {
+                let d = (pt(i) - q0).cross(dir)
+                if d < dMin { dMin = d } else if d > dMax { dMax = d }
+            }
+        }
+
+        // Clip curve against fat line: distances computed on demand via closure (no heap allocation).
+        return curve.withPointsDo { n, pt in
+            convexHullClipInterval(n: n, d: { (pt($0) - q0).cross(dir) }, dLow: dMin, dHigh: dMax)
+        }
+    }
+
+    // Bezier clipping main recursive entry.  Returns false if the iteration
+    // budget was exceeded (caller falls back to implicitization).
+    // swiftlint:disable function_parameter_count
+    static func bezierClipping<C1, C2>(
+        _ c1: Subcurve<C1>, _ c2: Subcurve<C2>,
+        _ results: inout [Intersection],
+        _ accuracy: CGFloat,
+        _ totalIterations: inout Int
+    ) -> Bool where C1: NonlinearBezierCurve, C2: NonlinearBezierCurve {
+
+        let maximumIterations    = 900
+        let maximumIntersections = c1.curve.order * c2.curve.order
+
+        totalIterations += 1
+        guard totalIterations  <= maximumIterations    else { return false }
+        guard results.count    <= maximumIntersections else { return false }
+
+        // Quick bounding-box rejection.
+        guard c1.curve.boundingBox.overlaps(c2.curve.boundingBox) else { return true }
+
+        // Clip c1 using the fat line of c2.
+        guard let clip1 = fatLineClip(curve: c1.curve, fatOf: c2.curve) else { return true }
+        let c1Ratio   = clip1.1 - clip1.0
+        let c1Reduced = c1.split(from: clip1.0, to: clip1.1)
+
+        // Clip c2 using the fat line of the (possibly narrowed) c1.
+        guard let clip2 = fatLineClip(curve: c2.curve, fatOf: c1Reduced.curve) else { return true }
+        let c2Ratio   = clip2.1 - clip2.0
+        let c2Reduced = c2.split(from: clip2.0, to: clip2.1)
+
+        // Geometric convergence check: both subcurves fit inside the accuracy threshold.
+        let b1 = c1Reduced.curve.boundingBox
+        let b2 = c2Reduced.curve.boundingBox
+        if b1.size.x + b1.size.y < accuracy && b2.size.x + b2.size.y < accuracy {
+            // Reject false positives: nearby non-intersecting sub-curves can both pass the
+            // size threshold. Require the reduced bounding boxes to be spatially close.
+            // Expand by `accuracy` to absorb floating-point rounding on degenerate curves.
+            guard b1.max.x + accuracy >= b2.min.x && b2.max.x + accuracy >= b1.min.x &&
+                  b1.max.y + accuracy >= b2.min.y && b2.max.y + accuracy >= b1.min.y else { return true }
+            let p1s = c1Reduced.curve.startingPoint
+            let p1e = c1Reduced.curve.endingPoint
+            let p2s = c2Reduced.curve.startingPoint
+            let p2e = c2Reduced.curve.endingPoint
+            var t1: CGFloat
+            var t2: CGFloat
+            // Exact shared-endpoint matching: point(at:0) and point(at:1) return the
+            // raw control points, so these equalities are bit-for-bit when curves share
+            // an original endpoint.
+            if p1s == p2s {
+                t1 = c1Reduced.t1; t2 = c2Reduced.t1
+            } else if p1s == p2e {
+                t1 = c1Reduced.t1; t2 = c2Reduced.t2
+            } else if p1e == p2s {
+                t1 = c1Reduced.t2; t2 = c2Reduced.t1
+            } else if p1e == p2e {
+                t1 = c1Reduced.t2; t2 = c2Reduced.t2
+            } else {
+                let l1 = LineSegment(p0: p1s, p1: p1e)
+                let l2 = LineSegment(p0: p2s, p1: p2e)
+                if l1.p0 != l1.p1, l2.p0 != l2.p1,
+                   let ix = l1.intersections(with: l2, checkCoincidence: false).first {
+                    t1 = ix.t1 * c1Reduced.t2 + (1 - ix.t1) * c1Reduced.t1
+                    t2 = ix.t2 * c2Reduced.t2 + (1 - ix.t2) * c2Reduced.t1
+                } else {
+                    t1 = 0.5 * (c1Reduced.t1 + c1Reduced.t2)
+                    t2 = 0.5 * (c2Reduced.t1 + c2Reduced.t2)
+                }
+            }
+            results.append(Intersection(t1: t1, t2: t2))
+            return true
+        }
+
+        // If either curve reduced by less than 20 %, convergence is slow — subdivide.
+        if c1Ratio > 0.8 || c2Ratio > 0.8 {
+            // Subdivide whichever has the larger global parameter range.
+            if (c1Reduced.t2 - c1Reduced.t1) >= (c2Reduced.t2 - c2Reduced.t1) {
+                guard c1Reduced.canSplit else {
+                    guard c2Reduced.canSplit else { return true }
+                    let h = c2Reduced.split(at: 0.5)
+                    guard bezierClipping(c1Reduced, h.left,  &results, accuracy, &totalIterations) else { return false }
+                    return  bezierClipping(c1Reduced, h.right, &results, accuracy, &totalIterations)
+                }
+                let h = c1Reduced.split(at: 0.5)
+                guard bezierClipping(h.left,  c2Reduced, &results, accuracy, &totalIterations) else { return false }
+                return  bezierClipping(h.right, c2Reduced, &results, accuracy, &totalIterations)
+            } else {
+                guard c2Reduced.canSplit else {
+                    guard c1Reduced.canSplit else { return true }
+                    let h = c1Reduced.split(at: 0.5)
+                    guard bezierClipping(h.left,  c2Reduced, &results, accuracy, &totalIterations) else { return false }
+                    return  bezierClipping(h.right, c2Reduced, &results, accuracy, &totalIterations)
+                }
+                let h = c2Reduced.split(at: 0.5)
+                guard bezierClipping(c1Reduced, h.left,  &results, accuracy, &totalIterations) else { return false }
+                return  bezierClipping(c1Reduced, h.right, &results, accuracy, &totalIterations)
+            }
+        }
+
+        // Good convergence — continue alternating clipping passes.
+        return bezierClipping(c1Reduced, c2Reduced, &results, accuracy, &totalIterations)
+    }
+    // swiftlint:enable function_parameter_count
+
     // disable this SwiftLint warning about function having more than 5 parameters
     // swiftlint:disable function_parameter_count
 


### PR DESCRIPTION
In QuadraticCurve.project and CubicCurve.project, the curve was translated using CGAffineTransform(translationX:y:) / .applying(), which calls external C functions and saves extra callee-saved float registers. Replace with direct CGPoint operator subtraction (p0 - point), which is idiomatic for this codebase and inlines to the same arithmetic without the transform overhead.