### PR TITLE
Replace CGAffineTransform translation with CGPoint subtraction in project()

### DIFF
--- a/BezierKit/Library/CubicCurve.swift
+++ b/BezierKit/Library/CubicCurve.swift
@@ -222,7 +222,7 @@ public struct CubicCurve: NonlinearBezierCurve, Equatable, Sendable {
         func mul(_ a: CGPoint, _ b: CGPoint) -> CGPoint {
             return CGPoint(x: a.x * b.x, y: a.y * b.y)
         }
-        let c = self.copy(using: CGAffineTransform(translationX: -point.x, y: -point.y))
+        let c = CubicCurve(p0: p0 - point, p1: p1 - point, p2: p2 - point, p3: p3 - point)
         let q = QuadraticCurve(p0: self.p1 - self.p0, p1: self.p2 - self.p1, p2: self.p3 - self.p2)
         // p0, p1, p2, p3 form the control points of a Cubic Bezier Curve formed
         // by multiplying the polynomials q and l

--- a/BezierKit/Library/QuadraticCurve.swift
+++ b/BezierKit/Library/QuadraticCurve.swift
@@ -137,7 +137,7 @@ public struct QuadraticCurve: NonlinearBezierCurve, Equatable, Sendable {
         func multiplyCoordinates(_ a: CGPoint, _ b: CGPoint) -> CGPoint {
             return CGPoint(x: a.x * b.x, y: a.y * b.y)
         }
-        let q = self.copy(using: CGAffineTransform(translationX: -point.x, y: -point.y))
+        let q = QuadraticCurve(p0: p0 - point, p1: p1 - point, p2: p2 - point)
         // p0, p1, p2, p3 form the control points of a cubic Bezier curve
         // created by multiplying the curve with its derivative
         let qd0 = q.p1 - q.p0


### PR DESCRIPTION
In QuadraticCurve.project and CubicCurve.project, the curve was translated using CGAffineTransform(translationX:y:) / .applying(), which calls external C functions and saves extra callee-saved float registers. Replace with direct CGPoint operator subtraction (p0 - point), which is idiomatic for this codebase and inlines to the same arithmetic without the transform overhead.
