### PR TITLE
Remove LinuxMain.swift

### DIFF
--- a/.github/workflows/wasmBuild.yml
+++ b/.github/workflows/wasmBuild.yml
@@ -8,10 +8,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    
-    # Carton is not able to find our tests if LinuxMain.swift file is defined
-    - name: Remove LinuxMain.swift file
-      run: rm BezierKit/LinuxMain.swift
 
     - name: Test
       run: carton test

--- a/BezierKit/LinuxMain.swift
+++ b/BezierKit/LinuxMain.swift
@@ -1,8 +1,0 @@
-import XCTest
-
-import BezierKitTests
-
-var tests = [XCTestCaseEntry]()
-tests += BezierKitTests.__allTests()
-
-XCTMain(tests)


### PR DESCRIPTION
## Why LinuxMain.swift existed

Before Swift 5.1, Swift Package Manager on Linux had no automatic test discovery. Apple platforms use the Objective-C runtime to enumerate `XCTestCase` subclasses at startup, but that runtime is unavailable on Linux. The workaround was a hand-written `LinuxMain.swift` at the package (or `Tests/`) root containing:

1. A static `allTests` property on every test class listing each test method by name.
2. A top-level entry point calling `XCTMain()` with all those arrays combined.

SPM used this file as the Linux test executable's `main`. Without it, no tests ran on Linux.

## Why it can be removed now

**SE-0238 / Swift 5.1 (2019)** introduced `--enable-test-discovery`, which generates the test registry synthetically at build time. SPM inspects the compiled module for `XCTestCase` subclasses and emits the boilerplate automatically — no `LinuxMain.swift` required.

**Swift 5.4 (2021)** made test discovery the default, so not even `--enable-test-discovery` is needed for modern toolchains.

## Why this file was already inert in this repo

Even before this PR, `LinuxMain.swift` was doing nothing useful:

- **Not part of any SPM target.** `Package.swift` lists the library target at `BezierKit/Library/` and the test target at `BezierKit/BezierKitTests/`. `BezierKit/LinuxMain.swift` falls outside both paths, so SPM never compiled it.
- **References a non-existent symbol.** The file calls `BezierKitTests.__allTests()`, but the per-class `allTests` boilerplate was never added to the test files in this repo. It would fail to link even if it were compiled.
- **CI already used `--enable-test-discovery`.** Both the Mac and Linux jobs in `ci.yml` already pass `--enable-test-discovery`, so SPM has been using automatic discovery all along.
- **The WASM workflow had to delete it manually.** `wasmBuild.yml` contained an explicit `rm BezierKit/LinuxMain.swift` step with the comment _"Carton is not able to find our tests if LinuxMain.swift file is defined"_ — a clear sign the file was actively harmful, not helpful. That workaround step is also removed in this PR.

## Effect on older Swift compilers

`Package.swift` declares `swift-tools-version:5.3`, which already requires Swift 5.3+. Swift 5.3 supports `--enable-test-discovery`, and the CI already passes that flag. Anyone building on Linux with Swift 5.3 is unaffected.

Pre-5.1 toolchains would have needed a properly written `LinuxMain.swift` with `allTests` boilerplate, but:
- That boilerplate was never present, so the file never worked for those toolchains anyway.
- `swift-tools-version:5.3` makes those toolchains unable to build the package at all.

There is no supported configuration that loses anything from this removal.

## Changes

- `BezierKit/LinuxMain.swift` — deleted
- `.github/workflows/wasmBuild.yml` — removed the now-unnecessary `rm LinuxMain.swift` workaround step

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2nVR13APTj6NEiGqx9wRB)_