### PR TITLE
Fix mergeNeighbors crash when duplicate intersections share a neighbor

### DIFF
--- a/BezierKit/BezierKitTests/Path+VectorBooleanTests.swift
+++ b/BezierKit/BezierKitTests/Path+VectorBooleanTests.swift
@@ -658,6 +658,21 @@ class PathVectorBooleanTests: XCTestCase {
         XCTAssertFalse(result.contains(point3, using: .evenOdd))
     }
 
+    func testCrossingsRemovedDuplicateNeighborCrash() {
+        // A degenerate cubic Bezier (start == end, with control points off that point) followed by a
+        // single line segment, closed back to the start. The degeneracy causes the bezier clipping
+        // algorithm to detect the same self-intersection twice, producing duplicate entries that
+        // triggered assert(self.neighborsContain(node) == false) in the old mergeNeighbors code.
+        let cgPath = CGMutablePath()
+        let P = CGPoint(x: -7.83203, y: 70.75)
+        cgPath.move(to: P)
+        cgPath.addCurve(to: P, control1: CGPoint(x: -7.77344, y: 70.8125), control2: CGPoint(x: -7.69531, y: 70.8125))
+        cgPath.addLine(to: CGPoint(x: -10.0938, y: 69.1875))
+        cgPath.closeSubpath()
+        let path = Path(cgPath: cgPath)
+        _ = path.crossingsRemoved(accuracy: 0.0001)  // should not crash
+    }
+
     func testCrossingsRemovedMulticomponent() {
         // this path is a square with a self-intersecting inner region that should form a square shaped hole when crossings
         // this is similar to what happens if you use CoreGraphics to stroke shape, albeit simplified here for the sake of testing

--- a/BezierKit/Library/AugmentedGraph.swift
+++ b/BezierKit/Library/AugmentedGraph.swift
@@ -42,15 +42,22 @@ private class Node {
         self.neighbors.append(node)
     }
     private func replaceNeighbor(_ node: Node, with replacement: Node) {
-        for i in self.neighbors.indices where self.neighbors[i] === node {
-            self.neighbors[i] = replacement
+        // if replacement is already present, just remove node to avoid creating a duplicate
+        let alreadyHasReplacement = neighborsContain(replacement)
+        neighbors = neighbors.compactMap {
+            guard $0 === node else { return $0 }
+            return alreadyHasReplacement ? nil : replacement
         }
     }
     func mergeNeighbors(of node: Node) {
         node.neighbors.forEach {
+            guard $0 !== self else { return }  // skip self-referential connections
             $0.replaceNeighbor(node, with: self)
-            self.addNeighbor($0)
+            if !self.neighborsContain($0) {
+                self.addNeighbor($0)
+            }
         }
+        self.neighbors = self.neighbors.filter { $0 !== node }
     }
     /// Nodes can have strong reference cycles either through their neighbors or through their edges, unlinking all nodes when owner no longer holds instance prevents memory leakage
     func unlink() {


### PR DESCRIPTION
## Summary

A degenerate cubic Bezier (start == end, with control points off that point) can cause the bezier clipping algorithm to detect the same self-intersection twice, producing duplicate nodes in `sortAndMergeDuplicates`. When merging those duplicate nodes, the old code crashed via `assert(self.neighborsContain(node) == false)` in `addNeighbor` because the neighbor was already present in the list.

**Root cause in `replaceNeighbor`:** The old code replaced `node` with `replacement` in the neighbors list unconditionally. If `replacement` was already present in the list (because both the original and the duplicate intersection shared the same neighbor), this created a duplicate. Then when `mergeNeighbors` called `addNeighbor`, the assertion fired.

**Fix:**
- `replaceNeighbor`: if `replacement` is already present, remove `node` instead of replacing it (avoiding duplicates).
- `mergeNeighbors`: guard against adding a neighbor that's already known, and filter out stale references to the merged-away node.

## Test

Added `testCrossingsRemovedDuplicateNeighborCrash` — a minimal repro using a degenerate loop curve followed by a line, which reliably triggered the assertion in the old code.

_Posted by Claude on behalf of @hfutrell._