### PR TITLE
Fix disjointComponents misclassifying inner component with boundary startingPoint

### DIFF
--- a/BezierKit/BezierKitTests/PathTests.swift
+++ b/BezierKit/BezierKitTests/PathTests.swift
@@ -853,6 +853,29 @@ class PathTests: XCTestCase {
         }
     }
 
+    func testDisjointComponentsInnerStartingPointOnOuterBoundary() {
+        // When an inner component's startingPoint lands exactly on another component's boundary,
+        // the winding count at that vertex is 0 (windingCountIncrementer uses strict point.x > xIntercept)
+        // so the old code misclassified the inner as a second outer component.
+        let outer = Path(components: [PathComponent(curves: [
+            LineSegment(p0: CGPoint(x: 0, y: 0),   p1: CGPoint(x: 100, y: 0)),
+            LineSegment(p0: CGPoint(x: 100, y: 0),  p1: CGPoint(x: 100, y: 100)),
+            LineSegment(p0: CGPoint(x: 100, y: 100), p1: CGPoint(x: 0, y: 100)),
+            LineSegment(p0: CGPoint(x: 0, y: 100),  p1: CGPoint(x: 0, y: 0))
+        ] as [BezierCurve])])
+        // inner triangle: startingPoint is (0, 50) — exactly on the outer's left boundary
+        // winding is CW so it is a hole inside the outer square
+        let inner = Path(components: [PathComponent(curves: [
+            LineSegment(p0: CGPoint(x: 0, y: 50),  p1: CGPoint(x: 20, y: 50)),
+            LineSegment(p0: CGPoint(x: 20, y: 50), p1: CGPoint(x: 10, y: 40)),
+            LineSegment(p0: CGPoint(x: 10, y: 40), p1: CGPoint(x: 0, y: 50))
+        ] as [BezierCurve])])
+        let path = Path(components: outer.components + inner.components)
+        let result = path.disjointComponents()
+        XCTAssertEqual(result.count, 1, "inner should be grouped with outer, not treated as a separate outer")
+        XCTAssertEqual(result.first?.components.count, 2)
+    }
+
     func testApply() {
 
         let emptyPath = Path()

--- a/BezierKit/Library/Path.swift
+++ b/BezierKit/Library/Path.swift
@@ -327,7 +327,12 @@ open class Path: NSObject, @unchecked Sendable {
         var innerComponents: [PathComponent] = []
         // determine which components are outer and which are inner
         for component in self.components {
-            let windingCount = self.windingCount(component.startingPoint, ignoring: component)
+            // Use midpoint of first curve rather than startingPoint: vertices can land exactly on
+            // another component's boundary, causing windingCount to return 0 (boundary exclusion)
+            // and misclassify an inner hole as a second outer. A curve midpoint is interior to the
+            // component and avoids this coincidence.
+            let probePoint = component.curves.first.map { $0.point(at: 0.5) } ?? component.startingPoint
+            let windingCount = self.windingCount(probePoint, ignoring: component)
             if windingCountImpliesContainment(windingCount, using: rule) {
                 innerComponents.append(component)
             } else {
@@ -336,12 +341,13 @@ open class Path: NSObject, @unchecked Sendable {
         }
         // file the inner components into their "owning" outer components
         for component in innerComponents {
+            let probePoint = component.curves.first.map { $0.point(at: 0.5) } ?? component.startingPoint
             var owner: PathComponent?
             for outer in outerComponents.keys {
                 if let owner = owner {
                     guard outer.boundingBox.intersection(owner.boundingBox) == outer.boundingBox else { continue }
                 }
-                if outer.contains(component.startingPoint, using: rule) {
+                if outer.contains(probePoint, using: rule) {
                     owner = outer
                 }
             }


### PR DESCRIPTION
## Summary

`windingCountIncrementer` uses `guard point.x > xIntercept` (strict), so a point exactly on a boundary segment returns 0. When an inner component's `startingPoint` lands precisely on another component's boundary, the old code got `windingCount == 0` and treated the inner hole as a second outer component instead of grouping it with its owner.

**Fix:** use the midpoint of the component's first curve as the probe point instead of `startingPoint`. A midpoint of a curve is offset into the interior and avoids the boundary-exclusion edge case. The same probe point is used in both the classification pass (inner vs outer) and the owner-filing pass.

## Test

Added `testDisjointComponentsInnerStartingPointOnOuterBoundary`: an outer 100×100 square and an inner triangle whose `startingPoint` is at `(0, 50)` — exactly on the outer's left edge. Without the fix, `disjointComponents()` returns 2 paths; with the fix, it correctly returns 1 path with 2 components.

_Posted by Claude on behalf of @hfutrell._