### PR TITLE
Use OSAllocatedUnfairLock with an NSLock fallback (#149)

### DIFF
--- a/BezierKit/BezierKitTests/LockTests.swift
+++ b/BezierKit/BezierKitTests/LockTests.swift
@@ -16,6 +16,18 @@ import XCTest
 
 #if !os(WASI)
 class LockTests: XCTestCase {
+
+    func testNSLockFallback() {
+        // NSLock is the implementation used on Linux/WASM and on Apple OS versions older
+        // than the OSAllocatedUnfairLock availability floor. On newer Apple platforms
+        // makeLock() never returns it at runtime, so exercise it directly for coverage.
+        let lock: any Lock = NSLock()
+        XCTAssertEqual(lock.sync { 42 }, 42)
+        var ran = false
+        lock.sync { ran = true }
+        XCTAssertTrue(ran)
+    }
+
     func testPathPropertyAtomicity() async {
 
         @MainActor class Results: Sendable {

--- a/BezierKit/Library/Lock.swift
+++ b/BezierKit/Library/Lock.swift
@@ -7,30 +7,50 @@
 //
 
 import Foundation
-
 #if canImport(Darwin)
-internal final class UnfairLock {
-    private let lockPointer: UnsafeMutablePointer<os_unfair_lock>
-    init() {
-        lockPointer = UnsafeMutablePointer<os_unfair_lock>.allocate(capacity: 1)
-        lockPointer.initialize(to: os_unfair_lock())
-    }
-    deinit {
-        lockPointer.deallocate()
-    }
+import os
+#endif
+
+/// A mutual-exclusion lock used to make external access of lazy properties threadsafe.
+///
+/// The backing primitive is chosen by availability via `makeLock()`: where
+/// `OSAllocatedUnfairLock` is available (iOS 16 / macOS 13 / tvOS 16 / watchOS 9 and
+/// newer) it is the preferred implementation; everywhere else (older Apple OS versions,
+/// Linux, WASM) the fallback is `NSLock`.
+///
+/// The protocol is deliberately not class-bound: both conformers are one word
+/// (`OSAllocatedUnfairLock` is a single managed buffer reference, `NSLock` is a class
+/// reference), so an `any Lock` stores them inline rather than boxing them.
+internal protocol Lock {
+    func sync<T>(_ f: () throws -> T) rethrows -> T
+}
+
+/// `NSLock` is the fallback used wherever `OSAllocatedUnfairLock` is unavailable.
+extension NSLock: Lock {
     func sync<T>(_ f: () throws -> T) rethrows -> T {
-        os_unfair_lock_lock(lockPointer)
-        defer { os_unfair_lock_unlock(lockPointer) }
+        lock()
+        defer { unlock() }
         return try f()
     }
 }
-#else
-internal final class UnfairLock {
-    private let lock = NSLock()
+
+#if canImport(Darwin)
+@available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+extension OSAllocatedUnfairLock: Lock where State == Void {
+    // withLockUnchecked (rather than withLock) because the protected closures capture
+    // `self` and return non-Sendable values, which the Sendable-constrained withLock rejects.
     func sync<T>(_ f: () throws -> T) rethrows -> T {
-        lock.lock()
-        defer { lock.unlock() }
-        return try f()
+        try withLockUnchecked(f)
     }
 }
 #endif
+
+/// Returns the preferred `Lock` implementation available on the current platform.
+internal func makeLock() -> any Lock {
+    #if canImport(Darwin)
+    if #available(macOS 13, iOS 16, tvOS 16, watchOS 9, *) {
+        return OSAllocatedUnfairLock(initialState: ())
+    }
+    #endif
+    return NSLock()
+}

--- a/BezierKit/Library/Path.swift
+++ b/BezierKit/Library/Path.swift
@@ -35,7 +35,7 @@ internal func windingCountImpliesContainment(_ count: Int, using rule: PathFillR
 
 open class Path: NSObject, @unchecked Sendable {
     /// lock to make external accessing of lazy vars threadsafe
-    private let lock = UnfairLock()
+    private let lock = makeLock()
 
     private class PathApplierFunctionContext {
         var currentPoint: CGPoint?

--- a/BezierKit/Library/PathComponent.swift
+++ b/BezierKit/Library/PathComponent.swift
@@ -17,7 +17,7 @@ open class PathComponent: NSObject, Reversible, Transformable, @unchecked Sendab
     public let points: [CGPoint]
     public let orders: [Int]
     /// lock to make external accessing of lazy vars threadsafe
-    private let lock = UnfairLock()
+    private let lock = makeLock()
 
     public var curves: [BezierCurve] { // in most cases use element(at:)
         return (0..<self.numberOfElements).map {


### PR DESCRIPTION
Resolves #149.

## What changed

`Path`/`PathComponent` guard their lazy properties with a lock selected by availability via `makeLock()`, behind a small internal `Lock` protocol:

| Platform | Lock |
|---|---|
| iOS 16 / macOS 13 / tvOS 16 / watchOS 9+ | `OSAllocatedUnfairLock` (owns its storage/lifecycle, `Sendable`, no manual `allocate`/`deallocate`) |
| older Apple OS, Linux, WASM | `NSLock` |

This removes the manually heap-allocated `os_unfair_lock` pointer and its hand-rolled lifecycle.

`OSAllocatedUnfairLock` and `NSLock` both conform to `Lock` **directly** — the former via an availability-gated conditional conformance, the latter via a plain extension — with no wrapper type. The protocol is not class-bound, and both conformers are a single word (a managed-buffer reference and a class reference), so `any Lock` stores either **inline** (8 bytes, well under the 24-byte existential buffer) rather than boxing it.

## Allocation count

- **Before:** the `os_unfair_lock` impl was a class + a separately-allocated `os_unfair_lock` buffer = **2 allocations** per lock.
- **After (modern path):** `OSAllocatedUnfairLock`'s `ManagedBuffer`, stored inline in the existential = **1 allocation** per lock.

(`OSAllocatedUnfairLock` does *not* store inline as the issue supposed — its SDK definition allocates a `ManagedBuffer`. The reduction here comes from dropping the wrapper object, not from `OSAllocatedUnfairLock` itself.)

## Benchmarks (release, `-c release`, steady-state per-op)

The relevant comparison — **`OSAllocatedUnfairLock` vs the previous `os_unfair_lock`** — on `sync`:

| Primitive | Sync (lock+unlock) |
|---|---|
| `OSAllocatedUnfairLock` | **~1.8 ns** |
| `os_unfair_lock` (previous) | **~1.8 ns** |

Identical. End-to-end (`testPathProjectPerformance`, the lock-heavy projection workload): **no measurable regression vs master**. Lock construction happens once per `Path`/`PathComponent` and is dominated by other setup, so the allocation change is about count/cleanliness, not a hot path.

## Why not store `OSAllocatedUnfairLock` directly (no protocol)

The deployment target (iOS 13 / macOS 10.12) is below `OSAllocatedUnfairLock`'s iOS 16 / macOS 13 floor, and Swift can't gate a *stored property* by availability. Selecting it at runtime needs the small `Lock` protocol; using it directly would require raising the minimum OS — out of scope.

## Testing

- Full suite passes (280 tests, 0 failures).
- Added a direct `NSLock` test so its fallback path is covered on Apple platforms (where `makeLock()` always returns the `OSAllocatedUnfairLock` conformer at runtime). Existing `testPathPropertyAtomicity` exercises the selected lock under contention.
- SwiftLint: 0 violations.
- `Lock.swift` line coverage is 100% across the CI matrix (the `return NSLock()` line is reached on Linux CI, where the Darwin block is compiled out).
- Verified the availability-gated conditional conformance compiles at deployment target macOS 10.12, and that the WASM branch compiles against the `wasm32-unknown-wasip1` SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)