### PR TITLE
Speed up two type-checking hot spots and add a budget check

### DIFF
--- a/BezierKit/Library/BezierCurve+Intersection.swift
+++ b/BezierKit/Library/BezierCurve+Intersection.swift
@@ -116,7 +116,10 @@ private func coincidenceCheck<U: BezierCurve, T: BezierCurve>(_ curve1: U, _ cur
 private extension BezierCurve {
     var derivativeBounds: CGFloat {
         let points = self.points
-        let speeds = (1..<points.count).map { points[$0] - points[$0 - 1] }.map { sqrt($0.dot($0)) }
+        let speeds: [CGFloat] = (1..<points.count).map { index in
+            let point: CGPoint = points[index] - points[index - 1]
+            return sqrt(point.dot(point))
+        }
         return CGFloat(self.order) * speeds.max()!
     }
 }

--- a/BezierKit/Library/BezierCurve+Intersection.swift
+++ b/BezierKit/Library/BezierCurve+Intersection.swift
@@ -308,31 +308,31 @@ internal func helperIntersectsCurveLine<U>(_ curve: U, _ line: LineSegment, reve
 extension CubicCurve {
 
     private var selfIntersectionInfo: (discriminant: CGFloat, canonicalPoint: CGPoint)? {
-        let d1 = self.p1 - self.p0
-        let d2 = self.p2 - self.p0
+        let d1: CGPoint = self.p1 - self.p0
+        let d2: CGPoint = self.p2 - self.p0
         // https://pomax.github.io/bezierinfo/#canonical
         // we'll use cramer's rule to find a matrix M that maps d1 -> (1, 0) and d2 -> (0, 1)
         // then compute the transform to canonical form as [[0, 1], [1, 1]] * M
-        let a = d1.x
-        let c = d1.y
-        let b = d2.x
-        let d = d2.y
-        let det = a * d - b * c
+        let a: CGFloat = d1.x
+        let c: CGFloat = d1.y
+        let b: CGFloat = d2.x
+        let d: CGFloat = d2.y
+        let det: CGFloat = a * d - b * c
         guard det != 0 else { return nil }
-        let d3 = self.p3 - self.p0
+        let d3: CGPoint = self.p3 - self.p0
         // find the coordinates of the last point in canonical form
-        let x = (1 / det) * (-c * d3.x + a * d3.y)
-        let y = (1 / det) * ((d - c) * d3.x + (a - b) * d3.y)
+        let x: CGFloat = (1 / det) * (-c * d3.x + a * d3.y)
+        let y: CGFloat = (1 / det) * ((d - c) * d3.x + (a - b) * d3.y)
         // use the coordinates of the last point to determine if any self-intersections exist
         guard x < 1 else { return nil }
-        let xSquared = x * x
-        let cuspEdge = -3 * xSquared + 6 * x - 12 * y + 9
+        let xSquared: CGFloat = x * x
+        let cuspEdge: CGFloat = -3 * xSquared + 6 * x - 12 * y + 9
         guard cuspEdge > 0 else { return nil }
         if x <= 0 {
-            let loopAtTZeroEdge = (-xSquared + 3 * x) / 3
+            let loopAtTZeroEdge: CGFloat = (-xSquared + 3 * x) / 3
             guard y >= loopAtTZeroEdge else { return nil }
         } else {
-            let loopAtTOneEdge = (sqrt(3 * (4 * x - xSquared)) - x) / 2
+            let loopAtTOneEdge: CGFloat = (sqrt(3 * (4 * x - xSquared)) - x) / 2
             guard y >= loopAtTOneEdge else { return nil }
         }
         return (discriminant: cuspEdge, canonicalPoint: CGPoint(x: x, y: y))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,3 +77,15 @@ export PATH="/tmp/swift-6.3-toolchain/usr/bin:$PATH"
 swift test --swift-sdk 6.3-RELEASE-wasm32-unknown-wasip1
 wasmtime --dir=. .build/wasm32-unknown-wasip1/debug/BezierKitPackageTests.xctest
 ```
+
+## Type-checking time budget
+
+Un-annotated arithmetic over `CGPoint`'s operator overloads (and chained `.map`/`.filter` that leave the intermediate element type to be inferred) can push a single expression into the hundreds of milliseconds to *type-check*. This is distinct from runtime performance: it barely affects an optimized build, but SourceKit re-type-checks live on every keystroke, so a slow expression makes the file stutter as you edit it, and it inflates incremental/debug builds.
+
+Before committing any change under `BezierKit/Library/`, you must run:
+```
+Scripts/check-type-check-time.sh
+```
+It builds the library with `-warn-long-function-bodies` / `-warn-long-expression-type-checking` at a per-body/expression budget (default 120ms, override with `TYPE_CHECK_LIMIT_MS`) and fails if anything exceeds it. The default sits between the library's current worst legitimate body (~85ms) and the operator-overload hot-spot class it guards against (~160ms+); re-calibrate `TYPE_CHECK_LIMIT_MS` if your machine is much slower or faster. Fix a flagged site by giving the expression explicit type annotations (e.g. `let p: CGPoint = a - b`, `let speeds: [CGFloat] = …`) or by collapsing a chained `.map`/`.filter` into one closure with an annotated result, so the solver stops exploring the operator overloads. You must not raise the budget to sidestep a regression.
+
+Do not enforce this budget in CI: hosted CI runners have variable, unreliable wall-clock build times, so the signal is only meaningful from a controlled local build. This is a check you run, not a CI gate.

--- a/Scripts/check-type-check-time.sh
+++ b/Scripts/check-type-check-time.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Fails if any function body or expression in the BezierKit library exceeds the
+# Swift type-checking time budget. Guards against reintroducing type-inference
+# hot spots — chiefly un-annotated arithmetic over CGPoint's operator overloads,
+# which can push a single expression into the hundreds of milliseconds and make
+# the file stutter in the editor (SourceKit re-type-checks live on every
+# keystroke). Fix a flagged site by giving the expression explicit type
+# annotations so the solver stops exploring the operator overloads.
+#
+# The budget is wall-clock, so it is machine-dependent. Run it locally (not in
+# CI, whose hosted runners have unreliable build times). The default sits
+# between the library's current worst legitimate body (~85ms) and the
+# operator-overload hot-spot class it guards against (~160ms and up), so it
+# catches regressions without flagging today's code. Override with
+# TYPE_CHECK_LIMIT_MS, and re-calibrate if the host is much slower/faster.
+
+set -euo pipefail
+
+LIMIT_MS="${TYPE_CHECK_LIMIT_MS:-120}"
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+LOG="$BUILD_DIR/build.log"
+
+echo "Type-checking BezierKit with a ${LIMIT_MS}ms per-body/expression budget…"
+
+# Fresh build path forces a full compile so every body is type-checked (and thus
+# timed) rather than served from the incremental cache.
+status=0
+swift build --build-path "$BUILD_DIR/.build" \
+  -Xswiftc -Xfrontend -Xswiftc -warn-long-function-bodies="$LIMIT_MS" \
+  -Xswiftc -Xfrontend -Xswiftc -warn-long-expression-type-checking="$LIMIT_MS" \
+  > "$LOG" 2>&1 || status=$?
+
+if [ "$status" -ne 0 ]; then
+  echo "swift build failed:"
+  cat "$LOG"
+  exit "$status"
+fi
+
+# Keep only the warning lines (drop the source-caret continuation lines) and dedupe.
+violations="$(grep "to type-check" "$LOG" | grep -v '^[[:space:]]*|' | sort -u || true)"
+
+if [ -n "$violations" ]; then
+  echo "FAIL: BezierKit type-checking budget (${LIMIT_MS}ms) exceeded:"
+  echo "$violations"
+  echo
+  echo "Give the flagged expression explicit type annotations (e.g. 'let p: CGPoint = a - b',"
+  echo "or collapse a chained .map/.filter into one closure with an annotated result) so the"
+  echo "type checker stops inferring intermediate types through CGPoint's operator overloads."
+  exit 1
+fi
+
+echo "OK — no function body or expression exceeded ${LIMIT_MS}ms."


### PR DESCRIPTION
Two getters in BezierKit were Swift type-checking hot spots — expressions leaning on `CGPoint`'s overloaded operators and/or mixed `CGFloat`/integer-literal arithmetic, leaving all intermediate types for the constraint solver to infer. This annotates them so the solver has the types directly (identical behavior), and adds a local check so the hot spots can't come back.

## Fixes

**1. `BezierCurve.derivativeBounds`** — collapsed the two-stage `.map { … }.map { … }` chain into a single `map` with explicit `CGPoint` / `[CGFloat]` annotations.

```swift
let speeds: [CGFloat] = (1..<points.count).map { index in
    let point: CGPoint = points[index] - points[index - 1]
    return sqrt(point.dot(point))
}
```

**2. `CubicCurve.selfIntersectionInfo`** — annotated the Cramer's-rule locals as `CGPoint` / `CGFloat` so the cusp-edge and loop-edge polynomials don't force integer-vs-float literal inference.

## Regression guard

`Scripts/check-type-check-time.sh` builds the library with `-warn-long-function-bodies` / `-warn-long-expression-type-checking` at a per-body/expression budget (default 120 ms, `TYPE_CHECK_LIMIT_MS` override) and fails on any violation. `CLAUDE.md` directs it to be run before committing changes under `BezierKit/Library/`.

It's **not** a CI gate on purpose: hosted CI runners have unreliable wall-clock build times, so the budget is only meaningful from a controlled local build. The 120 ms default sits between the library's worst legitimate body (~85 ms) and the operator-overload hot-spot class it guards against (~160 ms+).

## Results

Type-checking the `BezierKit/Library` sources standalone (arm64 iOS-sim, Xcode 26.2).

**Per-getter hot spot:**

| Getter | Before | After |
|---|---|---|
| `derivativeBounds` | ~162 ms | ~4 ms |
| `selfIntersectionInfo` | ~44 ms | ~8 ms |

**Whole-module compilation (whole-module build, median of runs):**

| After change | Type-check phase | Δ | Module compile (Debug) | Δ |
|---|---|---|---|---|
| Baseline | 1003 ms | — | 1537 ms | — |
| + `derivativeBounds` | 870 ms | −133 ms | 1403 ms | −134 ms |
| + `selfIntersectionInfo` | 840 ms | −30 ms | 1371 ms | −32 ms |
| **Both** | **840 ms** | **−163 ms (−16%)** | **1371 ms** | **−166 ms (−11%)** |

After both fixes, `Scripts/check-type-check-time.sh` passes at the 120 ms budget. The payoff is **editor responsiveness** (SourceKit re-type-checks live on every keystroke) and Debug / incremental builds; total Release compile is optimizer-dominated and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)